### PR TITLE
Use node glob syntax in ESLint/Prettier commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
         "start": "npm run assets && concurrently \"npm run watch\" \"npm run start -w @babylonjs/smart-filters-demo\"",
         "test": "jest",
         "format": "npm run format:check && npm run format:fix",
-        "format:check": "prettier --check ./packages/**/src/**/*.{ts,tsx,js,json,scss,css}",
-        "format:fix": "prettier --write ./packages/**/src/**/*.{ts,tsx,js,json,scss,css}",
+        "format:check": "prettier --check \"./packages/**/src/**/*.{ts,tsx,js,json,scss,css}\"",
+        "format:fix": "prettier --write \"./packages/**/src/**/*.{ts,tsx,js,json,scss,css}\"",
         "lint": "npm run lint:check && npm run lint:fix",
-        "lint:check": "eslint ./packages/**/src/**/*.{ts,tsx,js,json}",
-        "lint:fix": "eslint ./packages/**/src/**/*.{ts,tsx,js,json} --fix"
+        "lint:check": "eslint \"./packages/**/src/**/*.{ts,tsx,js,json}\"",
+        "lint:fix": "eslint \"./packages/**/src/**/*.{ts,tsx,js,json}\" --fix"
     },
     "workspaces": [
         "packages/core",


### PR DESCRIPTION
When executed on zsh, these commands throw errors about the glob if there are no files matching one of its patterns. Making glob expansions consistent with node glob syntax seems to prevent this. 