### PR TITLE
Move ESLint to CI step, make clean more complete, rename pixelate uniform to match convention

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -25,8 +25,19 @@ jobs:
           - script: "npm install"
             displayName: "Npm install"
 
+    - job: ESLint
+      displayName: "2. ESLint"
+      pool:
+          vmImage: "Ubuntu-latest"
+          demands: npm
+      steps:
+          - script: "npm install"
+            displayName: "Npm install"
+          - script: "npm run lint:check"
+            displayName: "Run ESLint Check"
+
     - job: UnitTests
-      displayName: "2. Unit Tests"
+      displayName: "3. Unit Tests"
       pool:
           vmImage: "Ubuntu-latest"
           demands: npm

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "postinstall": "npm run build",
         "clean": "npm run clean --workspaces",
         "assets": "npm run assets -w @babylonjs/smart-filters-editor",
-        "build": "npm run clean && npm run lint:check && npm run assets && npm run build:buildTools && npm run build:shaders && tsc -b -v && npm run build -w @babylonjs/smart-filters-demo",
+        "build": "npm run clean && npm run assets && npm run build:buildTools && npm run build:shaders && tsc -b -v && npm run build -w @babylonjs/smart-filters-demo",
         "build:buildTools": "npm run build -w @babylonjs/smart-filters",
         "build:shaders": "npm run build:runTools -w @babylonjs/smart-filters && npm run build:runTools -w @babylonjs/smart-filters-demo",
         "watch": "tsc -b -v -w",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
         "readme.md"
     ],
     "scripts": {
-        "clean": "rimraf dist && rimraf tsconfig.build.tsbuildinfo",
+        "clean": "rimraf dist && rimraf buildTools/dist && rimraf tsconfig.build.tsbuildinfo && rimraf ../tsconfig.buildTools.build.tsbuildinfo",
         "versionUp": "node buildTools/versionUp.js",
         "build": "npm run build:buildTools && npm run build:runTools && npm run build:core",
         "build:core": "tsc -p ./tsconfig.build.json",

--- a/packages/demo/src/configuration/blocks/effects/pixelateBlock.fragment.glsl
+++ b/packages/demo/src/configuration/blocks/effects/pixelateBlock.fragment.glsl
@@ -14,5 +14,5 @@ vec4 pixelate(vec2 vUV) { // main
 
     vec2 pixelateStep = floor(pixelate * vUV) / pixelate;
 
-    return vec4(texture2D(_input_, pixelateStep).rgb, 1.);
+    return vec4(texture2D(input, pixelateStep).rgb, 1.);
 }


### PR DESCRIPTION
There was an issue where changes in shaderConverter.ts wouldn't be picked up before ESLint ran.  To fix this, I decided to move lint checking to a CI step instead of build step (npm run build isn't part of the dev inner loop anyway).  I also made the clean step more complete, and fixed a naming convention issue flagged in a prior PR.