### PR TITLE
Make switching between SmartFilter sources less flexible

### DIFF
--- a/packages/demo/src/app.ts
+++ b/packages/demo/src/app.ts
@@ -34,13 +34,11 @@ const smartFilterLoader = new SmartFilterLoader(engine, renderer, smartFilterMan
 
 // Track the current Smart Filter
 let currentSmartFilter: SmartFilter | undefined;
-let currentSource: SmartFilterSource | undefined;
 
 // Whenever a new SmartFilter is loaded, update currentSmartFilter and start rendering
 smartFilterLoader.onSmartFilterLoadedObservable.add((event: SmartFilterLoadedEvent) => {
     SmartFilterEditor.Hide();
     currentSmartFilter = event.smartFilter;
-    currentSource = event.source;
     renderer.startRendering(currentSmartFilter, useTextureAnalyzer).catch((err: unknown) => {
         console.error("Could not start rendering", err);
     });
@@ -50,16 +48,16 @@ smartFilterLoader.onSmartFilterLoadedObservable.add((event: SmartFilterLoadedEve
         history.replaceState(null, "", window.location.pathname);
     }
 
-    // In case we fell back to the default SmartFilter (in-repo), update the <select>
+    // In case we fell back to the default (in-repo) SmartFilter, update the <select>
     if (event.source === SmartFilterSource.InRepo && smartFilterSelect.value !== currentSmartFilter.name) {
         localStorage.setItem(LocalStorageSmartFilterName, currentSmartFilter.name);
         smartFilterSelect.value = currentSmartFilter.name;
     }
 
     // Set appropriate footer
-    inRepoFooter.style.display = currentSource === SmartFilterSource.InRepo ? "block" : "none";
-    defaultFooter.style.display = currentSource === SmartFilterSource.InRepo ? "none" : "block";
-    sourceName.textContent = currentSource === SmartFilterSource.Snippet ? "snippet server" : "local file";
+    inRepoFooter.style.display = event.source === SmartFilterSource.InRepo ? "block" : "none";
+    defaultFooter.style.display = event.source === SmartFilterSource.InRepo ? "none" : "block";
+    sourceName.textContent = event.source === SmartFilterSource.Snippet ? "snippet server" : "local file";
 });
 
 /**

--- a/packages/demo/src/app.ts
+++ b/packages/demo/src/app.ts
@@ -24,7 +24,7 @@ const editActionLink = document.getElementById("editActionLink")!;
 const smartFilterSelect = document.getElementById("smartFilterSelect")! as HTMLSelectElement;
 const canvas = document.getElementById("renderCanvas")! as HTMLCanvasElement;
 const inRepoFooter = document.getElementById("inRepoFooter")!;
-const defaultFooter = document.getElementById("defaultFooter")!;
+const snippetAndFileFooter = document.getElementById("snippetAndFileFooter")!;
 const sourceName = document.getElementById("sourceName")!;
 
 // Create our services
@@ -54,10 +54,24 @@ smartFilterLoader.onSmartFilterLoadedObservable.add((event: SmartFilterLoadedEve
         smartFilterSelect.value = currentSmartFilter.name;
     }
 
-    // Set appropriate footer
-    inRepoFooter.style.display = event.source === SmartFilterSource.InRepo ? "block" : "none";
-    defaultFooter.style.display = event.source === SmartFilterSource.InRepo ? "none" : "block";
-    sourceName.textContent = event.source === SmartFilterSource.Snippet ? "snippet server" : "local file";
+    // Set appropriate footer elements based on source
+    switch (event.source) {
+        case SmartFilterSource.InRepo:
+            sourceName.textContent = "";
+            inRepoFooter.style.display = "block";
+            snippetAndFileFooter.style.display = "none";
+            break;
+        case SmartFilterSource.Snippet:
+            sourceName.textContent = "snippet server";
+            inRepoFooter.style.display = "none";
+            snippetAndFileFooter.style.display = "block";
+            break;
+        case SmartFilterSource.File:
+            sourceName.textContent = "local file";
+            inRepoFooter.style.display = "none";
+            snippetAndFileFooter.style.display = "block";
+            break;
+    }
 });
 
 /**

--- a/packages/demo/src/smartFilterLoader.ts
+++ b/packages/demo/src/smartFilterLoader.ts
@@ -21,6 +21,17 @@ export type HardCodedSmartFilterManifest = {
 
 export type SmartFilterManifest = HardCodedSmartFilterManifest | SerializedSmartFilterManifest;
 
+export enum SmartFilterSource {
+    Snippet,
+    InRepo,
+    File,
+}
+
+export type SmartFilterLoadedEvent = {
+    smartFilter: SmartFilter;
+    source: SmartFilterSource;
+};
+
 /**
  * Manges loading SmartFilters for the demo app
  */
@@ -30,7 +41,7 @@ export class SmartFilterLoader {
     private readonly _renderer: SmartFilterRenderer;
 
     public readonly snippetUrl = "https://snippet.babylonjs.com";
-    public readonly onSmartFilterLoadedObservable: Observable<SmartFilter>;
+    public readonly onSmartFilterLoadedObservable: Observable<SmartFilterLoadedEvent>;
     public readonly manifests: SmartFilterManifest[];
 
     public get defaultSmartFilterName(): string {
@@ -47,7 +58,7 @@ export class SmartFilterLoader {
         this._engine = engine;
         this._renderer = renderer;
         this.manifests = manifests;
-        this.onSmartFilterLoadedObservable = new Observable<SmartFilter>();
+        this.onSmartFilterLoadedObservable = new Observable<SmartFilterLoadedEvent>();
         if (this.manifests.length === 0) {
             throw new Error(
                 "No SmartFilterManifests were passed to the SmartFilterLoader - add some manifests to smartFilterManifests.ts"
@@ -62,19 +73,23 @@ export class SmartFilterLoader {
      * @param optimize - If true, the SmartFilter will be automatically optimized
      */
     public async loadFromManifest(name: string, optimize: boolean): Promise<SmartFilter> {
-        return this._loadSmartFilter(async () => {
-            const manifest = this.manifests.find((manifest) => manifest.name === name);
-            switch (manifest?.type) {
-                case "HardCoded": {
-                    return manifest.createSmartFilter(this._engine, this._renderer);
+        return this._loadSmartFilter(
+            async () => {
+                const manifest = this.manifests.find((manifest) => manifest.name === name);
+                switch (manifest?.type) {
+                    case "HardCoded": {
+                        return manifest.createSmartFilter(this._engine, this._renderer);
+                    }
+                    case "Serialized": {
+                        const smartFilterJson = await manifest.getSmartFilterJson();
+                        return this._deserializer.deserialize(this._engine, smartFilterJson);
+                    }
                 }
-                case "Serialized": {
-                    const smartFilterJson = await manifest.getSmartFilterJson();
-                    return this._deserializer.deserialize(this._engine, smartFilterJson);
-                }
-            }
-            throw new Error("Could not read manifest " + name);
-        }, optimize);
+                throw new Error("Could not read manifest " + name);
+            },
+            SmartFilterSource.InRepo,
+            optimize
+        );
     }
 
     /**
@@ -83,19 +98,23 @@ export class SmartFilterLoader {
      * @param optimize - If true, the SmartFilter will be automatically optimized
      */
     public async loadFromFile(file: File, optimize: boolean): Promise<SmartFilter> {
-        return this._loadSmartFilter(async () => {
-            // Await (data)
-            const data = await new Promise<string>((resolve, reject) => {
-                ReadFile(
-                    file,
-                    (data) => resolve(data),
-                    undefined,
-                    false,
-                    (error) => reject(error)
-                );
-            });
-            return this._deserializer.deserialize(this._engine, JSON.parse(data));
-        }, optimize);
+        return this._loadSmartFilter(
+            async () => {
+                // Await (data)
+                const data = await new Promise<string>((resolve, reject) => {
+                    ReadFile(
+                        file,
+                        (data) => resolve(data),
+                        undefined,
+                        false,
+                        (error) => reject(error)
+                    );
+                });
+                return this._deserializer.deserialize(this._engine, JSON.parse(data));
+            },
+            SmartFilterSource.File,
+            optimize
+        );
     }
 
     /**
@@ -109,27 +128,36 @@ export class SmartFilterLoader {
         version: string | undefined,
         optimize: boolean
     ): Promise<SmartFilter> {
-        return this._loadSmartFilter(async () => {
-            const response = await fetch(`${this.snippetUrl}/${snippetToken}/${version || ""}`);
+        return this._loadSmartFilter(
+            async () => {
+                const response = await fetch(`${this.snippetUrl}/${snippetToken}/${version || ""}`);
 
-            if (!response.ok) {
-                throw new Error(`Could not fetch snippet ${snippetToken}. Response was: ${response.statusText}`);
-            }
+                if (!response.ok) {
+                    throw new Error(`Could not fetch snippet ${snippetToken}. Response was: ${response.statusText}`);
+                }
 
-            const data = await response.json();
-            const snippet = JSON.parse(data.jsonPayload);
-            const serializedSmartFilter = JSON.parse(snippet.smartFilter);
+                const data = await response.json();
+                const snippet = JSON.parse(data.jsonPayload);
+                const serializedSmartFilter = JSON.parse(snippet.smartFilter);
 
-            return this._deserializer.deserialize(this._engine, serializedSmartFilter);
-        }, optimize);
+                return this._deserializer.deserialize(this._engine, serializedSmartFilter);
+            },
+            SmartFilterSource.Snippet,
+            optimize
+        );
     }
 
     /**
      * Internal method to reuse common loading logic and fallback handling.
      * @param loader - Function that loads the SmartFilter from some source
+     * @param source - Source of the SmartFilter (see SmartFilterSource)
      * @param optimize - If true, the SmartFilter will be automatically optimized
      */
-    private async _loadSmartFilter(loader: () => Promise<SmartFilter>, optimize: boolean): Promise<SmartFilter> {
+    private async _loadSmartFilter(
+        loader: () => Promise<SmartFilter>,
+        source: SmartFilterSource,
+        optimize: boolean
+    ): Promise<SmartFilter> {
         this._renderer.beforeRenderObservable.clear();
 
         // Load the SmartFilter using the provided function. If that fails, retry with the default SmartFilter.
@@ -149,7 +177,10 @@ export class SmartFilterLoader {
             smartFilter = this._optimize(smartFilter);
         }
 
-        this.onSmartFilterLoadedObservable.notifyObservers(smartFilter);
+        this.onSmartFilterLoadedObservable.notifyObservers({
+            smartFilter,
+            source: source,
+        });
 
         return smartFilter;
     }

--- a/packages/demo/src/smartFilterLoader.ts
+++ b/packages/demo/src/smartFilterLoader.ts
@@ -179,7 +179,7 @@ export class SmartFilterLoader {
 
         this.onSmartFilterLoadedObservable.notifyObservers({
             smartFilter,
-            source: source,
+            source,
         });
 
         return smartFilter;

--- a/packages/demo/www/index.html
+++ b/packages/demo/www/index.html
@@ -30,6 +30,10 @@
                 outline: none !important;
             }
 
+            .footer div {
+                display: none;
+            }
+
             .container {
                 display: grid;
                 grid-template-columns: auto 230px 494px 300px auto;
@@ -144,11 +148,17 @@
                 <canvas id="renderCanvas" width="1024" height="700"></canvas>
             </div>
             <div class="footer">
-                <p>
-                    SmartFilter:
-                    <select id="smartFilterSelect" title="SmartFilter"></select>
-                </p>
-                <p>To modify this list, see smartFilters.ts</p>
+                <div id = "inRepoFooter">
+                    <p>
+                        SmartFilter:
+                        <select id="smartFilterSelect" title="SmartFilter"></select>
+                    </p>
+                    <p>To modify this list, see smartFilters.ts</p>
+                </div>
+                <div id = "defaultFooter">
+                    <p>Viewing SmartFilter from <b id="sourceName">snippet server or local file</b>.</p>
+                    <p>To browse in-repo SmartFilters, reload the page with an empty hash.</p>
+                </div>
                 <p>
                     You can have a look at all the awesome tools from babylon at
                     <a href="https://www.babylonjs.com">our website</a>.

--- a/packages/demo/www/index.html
+++ b/packages/demo/www/index.html
@@ -155,7 +155,7 @@
                     </p>
                     <p>To modify this list, see smartFilters.ts</p>
                 </div>
-                <div id = "defaultFooter">
+                <div id = "snippetAndFileFooter">
                     <p>Viewing SmartFilter from <b id="sourceName">snippet server or local file</b>.</p>
                     <p>To browse in-repo SmartFilters, reload the page with an empty hash.</p>
                 </div>


### PR DESCRIPTION
This is a quick way to prevent some bugs that arise when switching between in-repo and snippet server-loaded SmartFilters. 
Once you load in a SmartFilter that is not an in-repo filter, you cannot go back to viewing them without refreshing the page (with a clean hash). 

The footer of the demo app will indicate which source the current SmartFilter was loaded from.