### PR TITLE
Publish editor preview package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ junit.xml
 **/node_modules/*
 
 # Build tools
-/packages/core/buildTools/dist/
+/packages/core/buildTools/
 
 # Local dist
 **/www/scripts/**

--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -15,8 +15,8 @@ jobs:
             displayName: "Npm install and build"
           - script: "npm run test"
             displayName: "Jest Unit Tests"
-          - script: "npm run versionUp -w @babylonjs/smart-filters && npm run versionUp -w @babylonjs/smart-filters-editor"
-            displayName: "Npm version up"
+          - script: "npm run preparePublish"
+            displayName: "Npm preparePublish (version setting, cross-package dependency configuration)"
           - task: Npm@1
             displayName: "Npm publish"
             inputs:

--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -15,11 +15,11 @@ jobs:
             displayName: "Npm install and build"
           - script: "npm run test"
             displayName: "Jest Unit Tests"
-          - script: "npm run versionUp -w @babylonjs/smart-filters"
+          - script: "npm run versionUp -w @babylonjs/smart-filters && npm run versionUp -w @babylonjs/smart-filters-editor"
             displayName: "Npm version up"
           - task: Npm@1
             displayName: "Npm publish"
             inputs:
                 command: "custom"
-                customCommand: "publish --tag preview --access public -w @babylonjs/smart-filters"
+                customCommand: "publish --tag preview --access public -w @babylonjs/smart-filters && publish --tag preview --access public -w @babylonjs/smart-filters-editor"
                 customEndpoint: "NPMWithAccessToken"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@babylonjs/smart-filters-root",
-    "version": "0.0.1",
+    "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@babylonjs/smart-filters-root",
-            "version": "0.0.1",
+            "version": "0.0.0",
             "hasInstallScript": true,
             "license": "MIT",
             "workspaces": [
@@ -15939,7 +15939,7 @@
         },
         "packages/demo": {
             "name": "@babylonjs/smart-filters-demo",
-            "version": "0.0.1",
+            "version": "0.0.0",
             "license": "MIT",
             "devDependencies": {
                 "@fortawesome/fontawesome-svg-core": "^6.1.0",
@@ -15966,7 +15966,7 @@
         },
         "packages/editor": {
             "name": "@babylonjs/smart-filters-editor",
-            "version": "0.0.1",
+            "version": "0.0.0",
             "license": "MIT",
             "devDependencies": {
                 "recursive-copy": "^2.0.13"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
         "format:fix": "prettier --write \"./packages/**/src/**/*.{ts,tsx,js,json,scss,css}\"",
         "lint": "npm run lint:check && npm run lint:fix",
         "lint:check": "eslint \"./packages/**/src/**/*.{ts,tsx,js,json}\"",
-        "lint:fix": "eslint \"./packages/**/src/**/*.{ts,tsx,js,json}\" --fix"
+        "lint:fix": "eslint \"./packages/**/src/**/*.{ts,tsx,js,json}\" --fix",
+        "preparePublish": "npm run preparePublish -w @babylonjs/smart-filters && npm run preparePublish -w @babylonjs/smart-filters"
     },
     "workspaces": [
         "packages/core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@babylonjs/smart-filters-root",
-    "version": "0.0.1",
+    "version": "0.0.0",
     "description": "Babylon.js Smart Filter monorepo",
     "author": {
         "name": "Sebastien VANDENBERGHE"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "lint": "npm run lint:check && npm run lint:fix",
         "lint:check": "eslint \"./packages/**/src/**/*.{ts,tsx,js,json}\"",
         "lint:fix": "eslint \"./packages/**/src/**/*.{ts,tsx,js,json}\" --fix",
-        "preparePublish": "npm run preparePublish -w @babylonjs/smart-filters && npm run preparePublish -w @babylonjs/smart-filters"
+        "preparePublish": "npm run preparePublish -w @babylonjs/smart-filters && npm run preparePublish -w @babylonjs/smart-filters-editor"
     },
     "workspaces": [
         "packages/core",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     ],
     "scripts": {
         "clean": "rimraf dist && rimraf buildTools && rimraf tsconfig.build.tsbuildinfo && rimraf ../../tsconfig.buildTools.build.tsbuildinfo",
-        "versionUp": "node buildTools/versionUp.js",
+        "versionUp": "node buildTools/versionUp.js --alpha",
         "build": "npm run build:buildTools && npm run build:runTools && npm run build:core",
         "build:core": "tsc -p ./tsconfig.build.json",
         "build:buildTools": "tsc -p ./tsconfig.buildTools.build.json",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,12 +38,12 @@
         "readme.md"
     ],
     "scripts": {
-        "clean": "rimraf dist && rimraf buildTools/dist && rimraf tsconfig.build.tsbuildinfo && rimraf ../tsconfig.buildTools.build.tsbuildinfo",
+        "clean": "rimraf dist && rimraf buildTools && rimraf tsconfig.build.tsbuildinfo && rimraf ../../tsconfig.buildTools.build.tsbuildinfo",
         "versionUp": "node buildTools/versionUp.js",
         "build": "npm run build:buildTools && npm run build:runTools && npm run build:core",
         "build:core": "tsc -p ./tsconfig.build.json",
         "build:buildTools": "tsc -p ./tsconfig.buildTools.build.json",
-        "build:runTools": "node buildTools/dist/shaderConverter.js ./src/blocks ../utils/shaderCodeUtils",
+        "build:runTools": "node buildTools/shaderConverter.js ./src/blocks ../utils/shaderCodeUtils",
         "watch": "tsc -p ./tsconfig.build.json --watch",
         "test": "echo \"Error: run test from the root of the monorepo\" && exit 1"
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     ],
     "scripts": {
         "clean": "rimraf dist && rimraf buildTools && rimraf tsconfig.build.tsbuildinfo && rimraf ../../tsconfig.buildTools.build.tsbuildinfo",
-        "versionUp": "node buildTools/versionUp.js --alpha",
+        "preparePublish": "node buildTools/versionUp.js --alpha",
         "build": "npm run build:buildTools && npm run build:runTools && npm run build:core",
         "build:core": "tsc -p ./tsconfig.build.json",
         "build:buildTools": "tsc -p ./tsconfig.buildTools.build.json",

--- a/packages/core/src/utils/buildTools/determineVersion.ts
+++ b/packages/core/src/utils/buildTools/determineVersion.ts
@@ -1,10 +1,13 @@
+import type { Nullable } from "@babylonjs/core/types";
+import type { ExecException } from "child_process";
+
 /**
  * Determines if the major and minor versions of two semver strings match
  * @param version1 - The first semver string
  * @param version2 - The second semver string
  * @returns True if the major and minor versions match, false otherwise
  */
-function majorAndMinorVersionsMatch(version1, version2) {
+function majorAndMinorVersionsMatch(version1: string, version2: string): boolean {
     const version1split = version1.split(".");
     const version2split = version2.split(".");
     return version1split[0] === version2split[0] && version1split[1] === version2split[1];
@@ -16,9 +19,12 @@ function majorAndMinorVersionsMatch(version1, version2) {
  * @param version - The semver string to operate on
  * @returns The incremented version string
  */
-function incrementPatchVersion(version) {
+function incrementPatchVersion(version: string): string {
     const spl = version.split(".");
-    spl[spl.length - 1] = Number.parseInt(spl[spl.length - 1]) + 1;
+    if (spl.length < 3) {
+        throw new Error("version string must have at least 3 parts");
+    }
+    spl[spl.length - 1] = (Number.parseInt(spl[spl.length - 1]!) + 1).toString();
     return spl.join(".");
 }
 
@@ -27,9 +33,12 @@ function incrementPatchVersion(version) {
  * @param version - The semver string to operate on
  * @returns The version string with the prerelease flag removed
  */
-export function removePrereleaseFlags(version) {
+export function removePrereleaseFlags(version: string): string {
     const spl = version.split(".");
-    spl[spl.length - 1] = Number.parseInt(spl[spl.length - 1]);
+    if (spl.length < 3) {
+        throw new Error("version string must have at least 3 parts");
+    }
+    spl[spl.length - 1] = Number.parseInt(spl[spl.length - 1]!).toString();
     return spl.join(".");
 }
 
@@ -40,7 +49,7 @@ export function removePrereleaseFlags(version) {
  * @param alpha - A flag to indicate if the version should have an alpha prerelease flag
  * @returns The version to use
  */
-export function determineVersion(npmVersion, packageJSONVersion, alpha) {
+export function determineVersion(npmVersion: Nullable<string>, packageJSONVersion: string, alpha: boolean): string {
     packageJSONVersion = removePrereleaseFlags(packageJSONVersion);
     npmVersion = npmVersion === null ? null : removePrereleaseFlags(npmVersion);
 
@@ -67,7 +76,7 @@ export function determineVersion(npmVersion, packageJSONVersion, alpha) {
  * @param stdout - The stdout string
  * @returns The version of the package
  */
-export function getNpmVersion(err, stdout) {
+export function getNpmVersion(err: Nullable<ExecException>, stdout: string): Nullable<string> {
     let npmVersion = null;
     if (err?.message && err.message.indexOf("E404") !== -1) {
         console.warn("NPM registry does not have a preview version.");

--- a/packages/core/src/utils/buildTools/versionUp.ts
+++ b/packages/core/src/utils/buildTools/versionUp.ts
@@ -1,19 +1,20 @@
 import * as fs from "fs";
-import { exec } from "child_process";
+import { exec, type ExecException } from "child_process";
 import { determineVersion, getNpmVersion } from "./determineVersion.js";
+import type { Nullable } from "@babylonjs/core/types.js";
 
-exec("npm view @babylonjs/smart-filters dist-tags.preview", (err, stdout) => {
+exec("npm view @babylonjs/smart-filters dist-tags.preview", (err: Nullable<ExecException>, stdout) => {
     const alpha = true;
 
     const packageText = fs.readFileSync("package.json");
-    const packageJSON = JSON.parse(packageText);
+    const packageJSON = JSON.parse(packageText.toString());
 
-    let npmVersion = getNpmVersion(err, stdout);
+    const npmVersion = getNpmVersion(err, stdout);
 
     console.log("Current NPM Registry version:", npmVersion);
     console.log("Current package.json version:", packageJSON.version);
 
-    let versionToUse = determineVersion(npmVersion, packageJSON.version, alpha);
+    const versionToUse = determineVersion(npmVersion, packageJSON.version, alpha);
 
     console.log("Version to use:", versionToUse);
 

--- a/packages/core/src/utils/buildTools/versionUp.ts
+++ b/packages/core/src/utils/buildTools/versionUp.ts
@@ -3,16 +3,19 @@ import { exec, type ExecException } from "child_process";
 import { determineVersion, getNpmVersion } from "./determineVersion.js";
 import type { Nullable } from "@babylonjs/core/types.js";
 
-exec("npm view @babylonjs/smart-filters dist-tags.preview", (err: Nullable<ExecException>, stdout) => {
-    const alpha = true;
+const alpha = process.argv.includes("--alpha");
+const packageText = fs.readFileSync("package.json");
+const packageJSON = JSON.parse(packageText.toString());
 
-    const packageText = fs.readFileSync("package.json");
-    const packageJSON = JSON.parse(packageText.toString());
-
+const packageName = packageJSON.name;
+console.log("Processing package:", packageName);
+console.log("Alpha flag:", alpha);
+console.log("Current package.json version:", packageJSON.version);
+console.log("Querying NPM Registry for last published version...");
+exec(`npm view ${packageName} dist-tags.preview`, (err: Nullable<ExecException>, stdout) => {
     const npmVersion = getNpmVersion(err, stdout);
 
     console.log("Current NPM Registry version:", npmVersion);
-    console.log("Current package.json version:", packageJSON.version);
 
     const versionToUse = determineVersion(npmVersion, packageJSON.version, alpha);
 

--- a/packages/core/src/utils/buildTools/versionUp.ts
+++ b/packages/core/src/utils/buildTools/versionUp.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import { exec, type ExecException } from "child_process";
-import { determineVersion, getNpmVersion } from "./determineVersion.js";
+import { compareVersions, determineVersion, getNpmVersion, type VersionType } from "./determineVersion.js";
 import type { Nullable } from "@babylonjs/core/types.js";
 
 const alpha = process.argv.includes("--alpha");
@@ -11,21 +11,42 @@ const packageName = packageJSON.name;
 console.log("Processing package:", packageName);
 console.log("Alpha flag:", alpha);
 console.log("Current package.json version:", packageJSON.version);
-console.log("Querying NPM Registry for last published version...");
-exec(`npm view ${packageName} dist-tags.preview`, (err: Nullable<ExecException>, stdout) => {
-    const npmVersion = getNpmVersion(err, stdout);
 
-    console.log("Current NPM Registry version:", npmVersion);
+/**
+ * Queries the NPM registry for the specified version type
+ * @param versionType - The type of version to query
+ * @param callback - The callback to call with the NPM version
+ */
+function queryNpmFeed(versionType: VersionType, callback: (npmVersion: Nullable<string>) => void) {
+    exec(`npm view ${packageName} dist-tags.${versionType}`, (err: Nullable<ExecException>, stdout) => {
+        let npmVersion = getNpmVersion(versionType, err, stdout);
+        if (npmVersion !== null) {
+            npmVersion = npmVersion.trim();
+            console.log(`NPM Registry ${versionType} version:`, npmVersion);
+        }
+        callback(npmVersion);
+    });
+}
 
-    const versionToUse = determineVersion(npmVersion, packageJSON.version, alpha);
+queryNpmFeed("preview", (npmPreviewVersion) => {
+    queryNpmFeed("latest", (npmLatestVersion) => {
+        let highestNpmVersion: Nullable<string> = npmLatestVersion;
+        if (npmPreviewVersion && (!highestNpmVersion || compareVersions(npmPreviewVersion, highestNpmVersion) === 1)) {
+            highestNpmVersion = npmPreviewVersion;
+        }
 
-    console.log("Version to use:", versionToUse);
+        console.log("Highest NPM Registry version:", highestNpmVersion);
 
-    if (packageJSON.version !== versionToUse) {
-        packageJSON.version = versionToUse;
-        fs.writeFileSync("package.json", JSON.stringify(packageJSON, null, 4));
-        console.log("Version updated in package.json");
-    } else {
-        console.log("No need to update package.json");
-    }
+        const versionToUse = determineVersion(highestNpmVersion, packageJSON.version, alpha);
+
+        console.log("Version to use:", versionToUse);
+
+        if (packageJSON.version !== versionToUse) {
+            packageJSON.version = versionToUse;
+            fs.writeFileSync("package.json", JSON.stringify(packageJSON, null, 4));
+            console.log("Version updated in package.json");
+        } else {
+            console.log("No need to update package.json");
+        }
+    });
 });

--- a/packages/core/test/unit/determineVersion.test.js
+++ b/packages/core/test/unit/determineVersion.test.js
@@ -1,4 +1,4 @@
-import { determineVersion, removePrereleaseFlags, getNpmVersion } from "../../src/utils/buildTools/determineVersion.js";
+import { determineVersion, removePrereleaseFlags, getNpmVersion } from "../../src/utils/buildTools/determineVersion.ts";
 
 describe("versionUp", () => {
     beforeAll(() => {

--- a/packages/core/test/unit/determineVersion.test.js
+++ b/packages/core/test/unit/determineVersion.test.js
@@ -1,4 +1,4 @@
-import { determineVersion, removePrereleaseFlags, getNpmVersion } from "../../buildTools/determineVersion.js";
+import { determineVersion, removePrereleaseFlags, getNpmVersion } from "../../src/utils/buildTools/determineVersion.js";
 
 describe("versionUp", () => {
     beforeAll(() => {

--- a/packages/core/test/unit/determineVersion.test.js
+++ b/packages/core/test/unit/determineVersion.test.js
@@ -1,4 +1,9 @@
-import { determineVersion, removePrereleaseFlags, getNpmVersion } from "../../src/utils/buildTools/determineVersion.ts";
+import {
+    determineVersion,
+    removePrereleaseFlags,
+    getNpmVersion,
+    compareVersions,
+} from "../../src/utils/buildTools/determineVersion.ts";
 
 describe("versionUp", () => {
     beforeAll(() => {
@@ -115,17 +120,84 @@ describe("versionUp", () => {
 
     describe("getNpmVersion", () => {
         it("should return the version if there is no error", () => {
-            expect(getNpmVersion(null, "1.2.3")).toBe("1.2.3");
+            expect(getNpmVersion("preview", null, "1.2.3")).toBe("1.2.3");
         });
 
         it("should return null if there is an E404 error", () => {
             const err = new Error("E404");
-            expect(getNpmVersion(err, null)).toBeNull();
+            expect(getNpmVersion("preview", err, null)).toBeNull();
         });
 
         it("should throw an error if there is a non-404 error", () => {
             const err = new Error("Some other error");
-            expect(() => getNpmVersion(err, null)).toThrow(err);
+            expect(() => getNpmVersion("preview", err, null)).toThrow(err);
         });
+    });
+
+    describe("compareVersions", () => {
+        it("should throw if version 1 does not have 3 parts", () => {
+            const version1 = "1.0.0";
+            const version2 = "1.0";
+            expect(() => compareVersions(version1, version2)).toThrow();
+        });
+
+        it("should throw if version 2 does not have 3 parts", () => {
+            const version1 = "1.0";
+            const version2 = "1.0.0";
+            expect(() => compareVersions(version1, version2)).toThrow();
+        });
+
+        it.each([
+            {
+                version1: "1.0.0",
+                version2: "1.0.0",
+                expectedResult: 0,
+            },
+            {
+                version1: "1.0.0",
+                version2: "2.0.0",
+                expectedResult: -1,
+            },
+            {
+                version1: "2.0.0",
+                version2: "1.0.0",
+                expectedResult: 1,
+            },
+            {
+                version1: "1.0.0",
+                version2: "1.1.0",
+                expectedResult: -1,
+            },
+            {
+                version1: "1.1.0",
+                version2: "1.0.0",
+                expectedResult: 1,
+            },
+            {
+                version1: "1.0.0",
+                version2: "1.0.1",
+                expectedResult: -1,
+            },
+            {
+                version1: "1.0.1",
+                version2: "1.0.0",
+                expectedResult: 1,
+            },
+            {
+                version1: "1.0.0-alpha",
+                version2: "1.0.1-alpha",
+                expectedResult: -1,
+            },
+            {
+                version1: "1.0.1-alpha",
+                version2: "1.0.0-alpha",
+                expectedResult: 1,
+            },
+        ])(
+            "when version1 is $version1 and version2 is $version2, it should return $expectedResult",
+            ({ version1, version2, expectedResult }) => {
+                expect(compareVersions(version1, version2)).toBe(expectedResult);
+            }
+        );
     });
 });

--- a/packages/core/tsconfig.buildTools.build.json
+++ b/packages/core/tsconfig.buildTools.build.json
@@ -3,7 +3,7 @@
 
     "compilerOptions": {
         "rootDir": "./src/utils/buildTools",
-        "outDir": "./buildTools/dist",
+        "outDir": "./buildTools",
         "composite": true
     },
 

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@babylonjs/smart-filters-demo",
     "private": true,
-    "version": "0.0.1",
+    "version": "0.0.0",
     "description": "Demo usage of Smart Filters, as well as dev inner loop for working on the core.",
     "author": {
         "name": "Sebastien VANDENBERGHE"

--- a/packages/demo/src/configuration/blocks/inputs/webCamInputBlock.ts
+++ b/packages/demo/src/configuration/blocks/inputs/webCamInputBlock.ts
@@ -2,7 +2,7 @@ import { Observable } from "@babylonjs/core/Misc/observable.js";
 import type { ThinEngine } from "@babylonjs/core/Engines/thinEngine.js";
 import { WebCamSession } from "./webCamSession";
 import { ConnectionPointType, type SmartFilter, type RuntimeData, InputBlock } from "@babylonjs/smart-filters";
-import type { IMonitorConnectionChanges } from "../../../../../editor/src/graphSystem/IMonitorConnectionChanges.js";
+import type { IMonitorConnectionChanges } from "@babylonjs/smart-filters-editor";
 
 export type WebCamSource = {
     name: string;

--- a/packages/editor/build/preparePublish.js
+++ b/packages/editor/build/preparePublish.js
@@ -1,0 +1,19 @@
+import * as fs from "fs";
+
+const corePackageText = fs.readFileSync("../core/package.json");
+const corePackageJSON = JSON.parse(corePackageText.toString());
+
+const editorPackageText = fs.readFileSync("package.json");
+const editorPackageJSON = JSON.parse(editorPackageText.toString());
+
+console.log("Setting editor package version to match core package version:", corePackageJSON.version);
+editorPackageJSON.version = corePackageJSON.version;
+
+console.log("Adding dependency on core package to editor package");
+if (!editorPackageJSON.dependencies) {
+    editorPackageJSON.dependencies = {};
+}
+editorPackageJSON.dependencies["@babylonjs/core"] = corePackageJSON.version;
+
+console.log("Saving changes to editor package.json");
+fs.writeFileSync("package.json", JSON.stringify(editorPackageJSON, null, 4));

--- a/packages/editor/build/preparePublish.js
+++ b/packages/editor/build/preparePublish.js
@@ -13,7 +13,7 @@ console.log("Adding dependency on core package to editor package");
 if (!editorPackageJSON.dependencies) {
     editorPackageJSON.dependencies = {};
 }
-editorPackageJSON.dependencies["@babylonjs/core"] = corePackageJSON.version;
+editorPackageJSON.dependencies["@babylonjs/smart-filters"] = corePackageJSON.version;
 
 console.log("Saving changes to editor package.json");
 fs.writeFileSync("package.json", JSON.stringify(editorPackageJSON, null, 4));

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -36,7 +36,7 @@
         "clean": "rimraf dist && rimraf tsconfig.build.tsbuildinfo",
         "assets": "node build/copyAssets.js",
         "build": "npm run assets && tsc -p ./tsconfig.build.json",
-        "versionUp": "node ../../node_modules/@babylonjs/smart-filters/dist/utils/buildTools/versionUp.js",
+        "versionUp": "node ../../node_modules/@babylonjs/smart-filters/dist/utils/buildTools/versionUp.js --alpha",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "devDependencies": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -36,6 +36,7 @@
         "clean": "rimraf dist && rimraf tsconfig.build.tsbuildinfo",
         "assets": "node build/copyAssets.js",
         "build": "npm run assets && tsc -p ./tsconfig.build.json",
+        "versionUp": "node ../../node_modules/@babylonjs/smart-filters/dist/utils/buildTools/versionUp.js",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "devDependencies": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -36,8 +36,8 @@
         "clean": "rimraf dist && rimraf tsconfig.build.tsbuildinfo",
         "assets": "node build/copyAssets.js",
         "build": "npm run assets && tsc -p ./tsconfig.build.json",
-        "versionUp": "node ../../node_modules/@babylonjs/smart-filters/dist/utils/buildTools/versionUp.js --alpha",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "preparePublish": "node build/preparePublish.js"
     },
     "devDependencies": {
         "recursive-copy": "^2.0.13"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@babylonjs/smart-filters-editor",
     "private": true,
-    "version": "0.0.1",
+    "version": "0.0.0",
     "description": "An editor for the smart filters.",
     "author": {
         "name": "Sebastien VANDENBERGHE"

--- a/packages/editor/readme.md
+++ b/packages/editor/readme.md
@@ -1,8 +1,12 @@
-# Babylon.js Smart Filters
+# Babylon.js Smart Filters - PREVIEW
+
+# PREVIEW WARNING
+
+This package is currently in preview form, and updates will likely include breaking changes. It is not yet intended to be used by other projects.
 
 ## Editor
 
-The package contains a visual editor for Smart Filters - it is currently in prototype form, and is only consumed by the demo package.
+The package contains a visual editor for Smart Filters - it is currently in preview form, and will undergo significant, possibly breaking, changes before leaving preview.
 
 ## How to use
 
@@ -11,16 +15,13 @@ The editor can be open with the following code:
 import { SmartFilterEditor } from "@babylonjs/smart-filters-editor";
 
 ```
+    // Configure options
+    const options: SmartFilterEditorOptions = {
+        ... // See SmartFilterEditorOptions docstrings
+    }
+
     // Display the editor
-    SmartFilterEditor.Show({
-        engine,
-        filter,
-        onRuntimeCreated: (runtime: SmartFilterRuntime) => {
-            renderer.setRuntime(runtime);
-        },
-    });
+    SmartFilterEditor.Show(options);
 ```
 
-The only 2 required pieces of information for the editor are the Babylon Engine to create a runtime for as well as the filter to edit.
-
-When editing, a new runtime will be created for each changes so it is the developer's responsibility to either discard or keep the previous one while rendering.
+The options provide the filter to display, information about the supported blocks, and callbacks for operations that must be implemented by the application hosting the application, such as rendering a newly created runtime, or loading and saving serialized versions of the Smart Filter.

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -3,6 +3,7 @@ export * from "./graphSystem/properties/genericNodePropertyComponent.js";
 export * from "./sharedComponents/lineContainerComponent.js";
 export * from "./globalState.js";
 export * from "./graphSystem/display/inputDisplayManager.js";
+export type { IMonitorConnectionChanges } from "./graphSystem/IMonitorConnectionChanges.js";
 export { createDefaultValue } from "./graphSystem/registerDefaultInput.js";
 
 export type { TexturePreset } from "./globalState.js";

--- a/packages/editor/src/smartFilterEditor.ts
+++ b/packages/editor/src/smartFilterEditor.ts
@@ -10,33 +10,116 @@ import { Popup } from "./sharedComponents/popup.js";
 import type { AnyInputBlock, BaseBlock, SmartFilter, SmartFilterRuntime } from "@babylonjs/smart-filters";
 import type { Nullable } from "@babylonjs/core/types.js";
 
+/**
+ * An object that contains all of the information the Editor needs to display and
+ * work with a set of Smart Filter blocks.
+ */
 export type BlockRegistration = {
+    /**
+     * Some blocks must appear only once in the graph (e.g. OutputBlock) - this function returns true if the block
+     * should be unique in the graph.
+     * @param block - The block to check
+     * @returns true if the block should be unique in the graph
+     */
     getIsUniqueBlock: (block: BaseBlock) => boolean;
+
+    /**
+     * Given a block's name, this function should return a new instance of that block with default values, or null if
+     * the block name is not recognized.
+     * @param blockType - The name of the block to create
+     * @param smartFilter - The Smart Filter to create the block for
+     * @returns A new instance of the block, or null if the block name is not recognized
+     */
     getBlockFromString(blockType: string, smartFilter: SmartFilter): Nullable<BaseBlock>;
+
+    /**
+     * If there is an InputBlock that needs special property setting UI, this function should return that UI, otherwise null.
+     * @param inputBlock - The selected InputBlock
+     * @param globalState - The global state
+     * @returns The UI for the input block, or null if the input block does not need special UI
+     */
     getInputNodePropertyComponent(inputBlock: AnyInputBlock, globalState: GlobalState): Nullable<JSX.Element>;
+
+    /**
+     * Intercepts the creation of an input block and can return specialized input blocks.
+     * @param globalState - The global state of the editor.
+     * @param type - The type of input block to create.
+     * @returns Optionally creates an InputBock and returns it, null otherwise
+     */
     createInputBlock(globalState: GlobalState, type: string): Nullable<BaseBlock>;
+
+    /**
+     * An object that contains the names of all of the blocks, organized by category.
+     */
     allBlockNames: { [key: string]: string[] };
+
+    /**
+     * An object that contains the tooltips for all of the blocks, keyed by block name.
+     */
     blockTooltips: { [key: string]: string };
+
+    /**
+     * Optional override of the InputDisplayManager to provide custom display for particular blocks if desired.
+     */
     inputDisplayManager?: any;
 };
 
+/**
+ * Options to configure the Smart Filter Editor
+ */
 export type SmartFilterEditorOptions = {
+    /**
+     * The ThinEngine to use
+     */
     engine: ThinEngine;
 
+    /**
+     * A BlockRegistration object which is responsible for providing the information
+     * required for the Editor to be able to display and work with the Smart Filter
+     * blocks the application uses. Note that each application may have its own set
+     * of blocks, so this information must be passed in and not baked into the editor.
+     */
     blockRegistration: BlockRegistration;
 
+    /**
+     * The Smart Filter to edit
+     */
     filter?: SmartFilter;
 
+    /**
+     * The host element to draw the editor in. If undefined, a popup window will be used.
+     */
     hostElement?: HTMLElement;
 
+    /**
+     * A callback that is responsible for doing the work of initiating a download of the
+     * serialized version of the Smart Filter.
+     */
     downloadSmartFilter: () => void;
 
+    /**
+     * A callback that is responsible for loading a serialized Smart Filter from the provided file,
+     * and should then call SmartFilterEditor.Show with the loaded Smart Filter.
+     */
     loadSmartFilter: (file: File) => Promise<SmartFilter>;
 
+    /**
+     * An optional callback to save the current Smart Filter to the snippet server.
+     * If not supplied, the button will not appear in the editor.
+     */
     saveToSnippetServer?: () => void;
 
+    /**
+     * An optional callback which is called when a new runtime is created due to the
+     * user editing the Smart Filter (beyond simply changing uniforms).
+     * It is used to allow the application to render the new runtime.
+     * @param runtime - The new runtime that was created
+     */
     onRuntimeCreated?: (runtime: SmartFilterRuntime) => void;
 
+    /**
+     * An optional array of texture presets to display in the editor.
+     */
     texturePresets?: TexturePreset[];
 };
 


### PR DESCRIPTION
The goal of this change is to publish the first preview of the editor package. The CD has been updated to not only update the version of the core package (that script was converted to TS from JS during this change), but it now also sets the editor to the same version number, and adds a dependency from the editor -> core using that version number as part of the publish preparation.

The versionUp script was also updated to take into account that a package can have both a preview and latest version, and it works based off the greater of those two numbers. This is in preparation for moving from alpha to non-alpha in the future.

Also added docstrings to the public interface of the editor and updated the readme.md.

This change also tweaks the versionUp script to be consumable by other packages, although that isn't used yet.