### PR TITLE
Add watch support for GLSL files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
         "build": "npm run build:buildTools && npm run build:runTools && npm run build:core",
         "build:core": "tsc -p ./tsconfig.build.json",
         "build:buildTools": "tsc -p ./tsconfig.buildTools.build.json",
-        "build:runTools": "node buildTools/shaderConverter.js ./src/blocks ../utils/shaderCodeUtils",
+        "build:runTools": "node buildTools/buildShaders.js ./src/blocks ../utils/shaderCodeUtils",
         "watch": "tsc -p ./tsconfig.build.json --watch",
         "test": "echo \"Error: run test from the root of the monorepo\" && exit 1"
     },

--- a/packages/core/src/utils/buildTools/buildShaders.ts
+++ b/packages/core/src/utils/buildTools/buildShaders.ts
@@ -1,0 +1,13 @@
+/**
+ * Builds all .glsl files under <shaderPath>.
+ * @param shaderPath The path to the shaders to watch
+ * @param importPath The path to import the converted shaders
+ * @example node buildShaders.js <shaderPath> <importPath>
+ */
+
+import { convertShaders } from "./shaderConverter.js";
+
+const externalArguments = process.argv.slice(2);
+if (externalArguments.length >= 2 && externalArguments[0] && externalArguments[1]) {
+    convertShaders(externalArguments[0], externalArguments[1]);
+}

--- a/packages/core/src/utils/buildTools/shaderConverter.ts
+++ b/packages/core/src/utils/buildTools/shaderConverter.ts
@@ -63,7 +63,7 @@ const GetFunctionNamesRegEx = /\S*\w+\s+(\w+)\s*\(/g;
  * @param fragmentShaderPath - The path to the fragment file for the shader
  * @param importPath - The path to import the ShaderProgram type from
  */
-function convertShader(fragmentShaderPath: string, importPath: string): void {
+export function convertShader(fragmentShaderPath: string, importPath: string): void {
     console.log(`Processing fragment shader: ${fragmentShaderPath}`);
 
     // See if there is a corresponding vertex shader
@@ -376,7 +376,7 @@ function removeFunctionBodies(input: string): string {
  * @param shaderPath - The path to the .glsl files to convert.
  * @param importPath - The path to import the ShaderProgram type from.
  */
-function convertShaders(shaderPath: string, importPath: string) {
+export function convertShaders(shaderPath: string, importPath: string) {
     // Get all files in the path
     const allFiles = fs.readdirSync(shaderPath, { withFileTypes: true, recursive: true });
 
@@ -389,11 +389,6 @@ function convertShaders(shaderPath: string, importPath: string) {
     for (const fragmentShaderFile of fragmentShaderFiles) {
         convertShader(path.join(fragmentShaderFile.path, fragmentShaderFile.name), importPath);
     }
-}
-
-const externalArguments = process.argv.slice(2);
-if (externalArguments.length >= 2 && externalArguments[0] && externalArguments[1]) {
-    convertShaders(externalArguments[0], externalArguments[1]);
 }
 
 // TODO: simple copy from shader file to .ts, get it to build (including import trick)

--- a/packages/core/src/utils/buildTools/watchShaders.ts
+++ b/packages/core/src/utils/buildTools/watchShaders.ts
@@ -6,16 +6,16 @@
  */
 
 import { convertShader } from "./shaderConverter.js";
-import * as chokidar from "chokidar";
-import * as path from "path";
+import { watch } from "chokidar";
+import { extname } from "path";
 
 const externalArguments = process.argv.slice(2);
 if (externalArguments.length >= 2 && externalArguments[0] && externalArguments[1]) {
     const shaderPath = externalArguments[0];
     const importPath = externalArguments[1];
 
-    chokidar.watch(shaderPath).on("change", (file) => {
-        if (path.extname(file) === ".glsl") {
+    watch(shaderPath).on("change", (file) => {
+        if (extname(file) === ".glsl") {
             convertShader(file, importPath);
         }
     });

--- a/packages/core/src/utils/buildTools/watchShaders.ts
+++ b/packages/core/src/utils/buildTools/watchShaders.ts
@@ -1,0 +1,23 @@
+/**
+ * Watches all .glsl files under <shaderPath> and rebuild them when changed.
+ * @arg shaderPath The path to the shaders to watch
+ * @arg importPath The path to import the converted shaders
+ * @example node watchShaders.js <shaderPath> <importPath>
+ */
+
+import { convertShader } from "./shaderConverter.js";
+import * as chokidar from "chokidar";
+import * as path from "path";
+
+const externalArguments = process.argv.slice(2);
+if (externalArguments.length >= 2 && externalArguments[0] && externalArguments[1]) {
+    const shaderPath = externalArguments[0];
+    const importPath = externalArguments[1];
+
+    chokidar.watch(shaderPath).on("change", (file) => {
+        if (path.extname(file) === ".glsl") {
+            convertShader(file, importPath);
+        }
+    });
+    console.log(`Watching for shader changes in ${shaderPath}`);
+}

--- a/packages/core/src/utils/buildTools/watchShaders.ts
+++ b/packages/core/src/utils/buildTools/watchShaders.ts
@@ -1,5 +1,5 @@
 /**
- * Watches all .glsl files under <shaderPath> and rebuild them when changed.
+ * Watches all .glsl files under <shaderPath> and rebuilds them when changed.
  * @arg shaderPath The path to the shaders to watch
  * @arg importPath The path to import the converted shaders
  * @example node watchShaders.js <shaderPath> <importPath>

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -21,9 +21,10 @@
     "license": "MIT",
     "scripts": {
         "build": "npm run build:runTools && webpack --env=prod",
-        "build:runTools": "node ../../node_modules/@babylonjs/smart-filters/dist/utils/buildTools/shaderConverter.js ./src/configuration/blocks @babylonjs/smart-filters",
+        "build:runTools": "node ../../node_modules/@babylonjs/smart-filters/dist/utils/buildTools/buildShaders.js ./src/configuration/blocks @babylonjs/smart-filters",
+        "watch": "node ../../node_modules/@babylonjs/smart-filters/dist/utils/buildTools/watchShaders.js ./src/configuration/blocks @babylonjs/smart-filters",
         "clean": "rimraf .temp && rimraf www/scripts",
-        "start": "npx webpack-dev-server",
+        "start": "concurrently \"npx webpack-dev-server\" \"npm run watch\"",
         "analyze": "webpack --profile --json > www/scripts/stats.json && npx webpack-bundle-analyzer www/scripts/stats.json"
     },
     "devDependencies": {


### PR DESCRIPTION
- Turn shaderConverter into a module, to be reused by new buildShader and watchShader scripts
- Add watch script to demo app's glsl blocks, to be used by start script