### PR TITLE
Editor fixes around asset / animation lifecycle and direct input to output connections

### DIFF
--- a/packages/core/src/blocks/outputBlock.ts
+++ b/packages/core/src/blocks/outputBlock.ts
@@ -47,7 +47,7 @@ export class OutputBlock extends BaseBlock {
         if (!this._copyBlock) {
             this._copyBlock = new CopyBlock(this.smartFilter, "CopyToOutputBlock");
         }
-        this._copyBlock.input.runtimeData = this.input.connectedTo?.runtimeData ?? null;
+        this._copyBlock.input.runtimeData = this.input.runtimeData;
 
         return this._copyBlock;
     }

--- a/packages/core/src/serialization/smartFilterSerializer.ts
+++ b/packages/core/src/serialization/smartFilterSerializer.ts
@@ -3,7 +3,7 @@ import type { BaseBlock } from "../blocks/baseBlock";
 import { inputBlockSerializer } from "../blocks/inputBlock.serializer.js";
 import type { ConnectionPoint } from "../connection/connectionPoint";
 import { defaultBlockSerializer } from "./v1/defaultBlockSerializer.js";
-import { CopyBlockForOutputBlockName, OutputBlock } from "../blocks/outputBlock.js";
+import { OutputBlock } from "../blocks/outputBlock.js";
 import type {
     IBlockSerializerV1,
     ISerializedBlockV1,
@@ -11,7 +11,6 @@ import type {
     SerializeBlockV1,
     SerializedSmartFilterV1,
 } from "./v1/serialization.types";
-import { CopyBlock } from "../blocks/copyBlock.js";
 
 /**
  * Determines if two serialized connection points are equivalent to each other
@@ -61,11 +60,6 @@ export class SmartFilterSerializer {
         const connections: ISerializedConnectionV1[] = [];
 
         const blocks = smartFilter.attachedBlocks.map((block: BaseBlock) => {
-            // Special case: do not serialize the special CopyBlock created by the OutputBlock
-            if (block.getClassName() === CopyBlock.ClassName && block.name === CopyBlockForOutputBlockName) {
-                return null;
-            }
-
             // Serialize the block itself
             const serializeFn = this._blockSerializers.get(block.getClassName());
             if (!serializeFn) {
@@ -112,7 +106,7 @@ export class SmartFilterSerializer {
             name: smartFilter.name,
             comments: smartFilter.comments,
             editorData: smartFilter.editorData,
-            blocks: blocks.filter((block: ISerializedBlockV1 | null) => block !== null),
+            blocks,
             connections,
         };
     }

--- a/packages/core/src/serialization/smartFilterSerializer.ts
+++ b/packages/core/src/serialization/smartFilterSerializer.ts
@@ -3,7 +3,7 @@ import type { BaseBlock } from "../blocks/baseBlock";
 import { inputBlockSerializer } from "../blocks/inputBlock.serializer.js";
 import type { ConnectionPoint } from "../connection/connectionPoint";
 import { defaultBlockSerializer } from "./v1/defaultBlockSerializer.js";
-import { OutputBlock } from "../blocks/outputBlock.js";
+import { CopyBlockForOutputBlockName, OutputBlock } from "../blocks/outputBlock.js";
 import type {
     IBlockSerializerV1,
     ISerializedBlockV1,
@@ -11,6 +11,7 @@ import type {
     SerializeBlockV1,
     SerializedSmartFilterV1,
 } from "./v1/serialization.types";
+import { CopyBlock } from "../blocks/copyBlock.js";
 
 /**
  * Determines if two serialized connection points are equivalent to each other
@@ -60,6 +61,11 @@ export class SmartFilterSerializer {
         const connections: ISerializedConnectionV1[] = [];
 
         const blocks = smartFilter.attachedBlocks.map((block: BaseBlock) => {
+            // Special case: do not serialize the special CopyBlock created by the OutputBlock
+            if (block.getClassName() === CopyBlock.ClassName && block.name === CopyBlockForOutputBlockName) {
+                return null;
+            }
+
             // Serialize the block itself
             const serializeFn = this._blockSerializers.get(block.getClassName());
             if (!serializeFn) {
@@ -106,7 +112,7 @@ export class SmartFilterSerializer {
             name: smartFilter.name,
             comments: smartFilter.comments,
             editorData: smartFilter.editorData,
-            blocks,
+            blocks: blocks.filter((block: ISerializedBlockV1 | null) => block !== null),
             connections,
         };
     }

--- a/packages/core/src/smartFilter.ts
+++ b/packages/core/src/smartFilter.ts
@@ -142,19 +142,6 @@ export class SmartFilter {
         const outputBlock = this.outputBlock;
 
         outputBlock.visit(initializationData, (block: BaseBlock, initializationData: InitializationData) => {
-            // If the block is the output block,
-            if (block === outputBlock) {
-                // We only need to do something if the connected block is an input block.
-                // Indeed, any other block linked to the output block would directly render to the canvas
-                // as an optimization.
-                // In case the output block is not linked to an input block, we do not need extra commands
-                // or resources to create a render pass.
-                if (outputBlock.input.connectedTo?.ownerBlock.isInput) {
-                    block.generateCommandsAndGatherInitPromises(initializationData, true);
-                }
-                return;
-            }
-
             block.generateCommandsAndGatherInitPromises(
                 initializationData,
                 outputBlock.input.connectedTo?.ownerBlock === block

--- a/packages/demo/src/configuration/blockDeserializers.ts
+++ b/packages/demo/src/configuration/blockDeserializers.ts
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { type SmartFilter, type DeserializeBlockV1, type ISerializedBlockV1 } from "@babylonjs/smart-filters";
+import {
+    type SmartFilter,
+    type DeserializeBlockV1,
+    type ISerializedBlockV1,
+    CopyBlock,
+} from "@babylonjs/smart-filters";
 import { BlockNames } from "./blocks/blockNames";
 
 /**
@@ -154,6 +159,10 @@ export function getBlockDeserializers(): Map<string, DeserializeBlockV1> {
     deserializers.set(BlockNames.sketch, async (smartFilter: SmartFilter, serializedBlock: ISerializedBlockV1) => {
         const { SketchBlock } = await import(/* webpackChunkName: "sketchBlock" */ "./blocks/effects/sketchBlock");
         return new SketchBlock(smartFilter, serializedBlock.name);
+    });
+
+    deserializers.set(BlockNames.copy, async (smartFilter: SmartFilter, serializedBlock: ISerializedBlockV1) => {
+        return new CopyBlock(smartFilter, serializedBlock.name);
     });
 
     // Non-trivial deserializers begin.

--- a/packages/demo/src/configuration/blockSerializers.ts
+++ b/packages/demo/src/configuration/blockSerializers.ts
@@ -32,6 +32,7 @@ export const blocksUsingDefaultSerialization: string[] = [
     BlockNames.aurora,
     BlockNames.softThreshold,
     BlockNames.sketch,
+    BlockNames.copy,
 ];
 
 /**

--- a/packages/demo/src/configuration/blocks/blockNames.ts
+++ b/packages/demo/src/configuration/blocks/blockNames.ts
@@ -1,4 +1,5 @@
 export const BlockNames = {
+    copy: "CopyBlock",
     pixelate: "PixelateBlock",
     blackAndWhite: "BlackAndWhiteBlock",
     exposure: "ExposureBlock",

--- a/packages/demo/src/configuration/blocks/effects/maskBlock.fragment.glsl
+++ b/packages/demo/src/configuration/blocks/effects/maskBlock.fragment.glsl
@@ -6,5 +6,5 @@ vec4 maskBlock(vec2 vUV) { // main
     vec3 maskColor = texture2D(maskTexture, vUV).rgb;
     float luminance = dot(maskColor, vec3(0.3, 0.59, 0.11));
 
-    return vec4(color, luminance);
+    return vec4(color * luminance, luminance);
 }

--- a/packages/demo/src/helpers/launchEditor.ts
+++ b/packages/demo/src/helpers/launchEditor.ts
@@ -1,10 +1,4 @@
-import {
-    type BaseBlock,
-    logCommands,
-    type SmartFilter,
-    type SmartFilterRuntime,
-    SmartFilterSerializer,
-} from "@babylonjs/smart-filters";
+import { type BaseBlock, logCommands, type SmartFilter, SmartFilterSerializer } from "@babylonjs/smart-filters";
 import { blockEditorRegistrations } from "../configuration/editor/blockEditorRegistrations";
 import { type BlockRegistration, SmartFilterEditor } from "@babylonjs/smart-filters-editor";
 import { createInputBlock } from "../configuration/editor/createInputBlock";
@@ -19,7 +13,6 @@ import { StringTools } from "@babylonjs/shared-ui-components/stringTools";
 import { additionalBlockSerializers, blocksUsingDefaultSerialization } from "../configuration/blockSerializers";
 import type { SmartFilterLoader } from "../smartFilterLoader";
 import { getSnippet, setSnippet } from "./hashFunctions";
-import { registerAnimations } from "./registerAnimations";
 
 /**
  * Launches the editor - in a separate file so it can be dynamically imported, since it brings in code which
@@ -69,9 +62,10 @@ export function launchEditor(
             engine,
             blockRegistration,
             filter: currentSmartFilter,
-            onRuntimeCreated: (runtime: SmartFilterRuntime) => {
-                renderer.setRuntime(runtime);
-                registerAnimations(currentSmartFilter, renderer);
+            rebuildRuntime: (smartFilter: SmartFilter) => {
+                renderer.startRendering(smartFilter).catch((err: unknown) => {
+                    console.error("Could not start rendering", err);
+                });
             },
             downloadSmartFilter: () => {
                 const serializer = new SmartFilterSerializer(

--- a/packages/demo/src/helpers/registerAnimations.ts
+++ b/packages/demo/src/helpers/registerAnimations.ts
@@ -1,12 +1,16 @@
 import { ConnectionPointType, type SmartFilter, type InputBlock } from "@babylonjs/smart-filters";
 import type { SmartFilterRenderer } from "../smartFilterRenderer";
+import type { Observer } from "@babylonjs/core/Misc/observable";
 
 /**
  * Registers animations for the Smart Filter.
  * @param smartFilter - The Smart Filter to register animations for
  * @param renderer - The Smart Filter renderer
+ * @returns A function to unregister the animations
  */
-export function registerAnimations(smartFilter: SmartFilter, renderer: SmartFilterRenderer): void {
+export function registerAnimations(smartFilter: SmartFilter, renderer: SmartFilterRenderer): () => void {
+    const observers: Observer<void>[] = [];
+
     for (const block of smartFilter.attachedBlocks) {
         if (block.getClassName() === "InputBlock" && (block as any).type === ConnectionPointType.Float) {
             const inputBlock = block as InputBlock<ConnectionPointType.Float>;
@@ -15,13 +19,21 @@ export function registerAnimations(smartFilter: SmartFilter, renderer: SmartFilt
                 let currentTime = performance.now();
                 let lastTime = performance.now();
 
-                renderer.beforeRenderObservable.add(() => {
+                const observer = renderer.beforeRenderObservable.add(() => {
                     currentTime = performance.now();
                     deltaPerMs = inputBlock.editorData?.valueDeltaPerMs ?? 0.001;
                     inputBlock.runtimeValue.value += (currentTime - lastTime) * deltaPerMs;
                     lastTime = currentTime;
                 });
+
+                observers.push(observer);
             }
         }
     }
+
+    return () => {
+        for (const observer of observers) {
+            renderer.beforeRenderObservable.remove(observer);
+        }
+    };
 }

--- a/packages/demo/src/smartFilterLoader.ts
+++ b/packages/demo/src/smartFilterLoader.ts
@@ -4,16 +4,12 @@ import {
     type SmartFilter,
     SmartFilterDeserializer,
     type DeserializeBlockV1,
-    type InputBlock,
-    ConnectionPointType,
 } from "@babylonjs/smart-filters";
 import type { SmartFilterRenderer } from "./smartFilterRenderer";
 import type { TextureRenderHelper } from "./texureRenderHelper";
 import { Observable } from "@babylonjs/core/Misc/observable";
 import type { Nullable } from "@babylonjs/core/types";
 import { ReadFile } from "@babylonjs/core/Misc/fileTools";
-import { loadTextureInputBlockAsset } from "@babylonjs/smart-filters-editor";
-import { registerAnimations } from "./helpers/registerAnimations";
 
 export type SerializedSmartFilterManifest = {
     type: "Serialized";
@@ -197,26 +193,7 @@ export class SmartFilterLoader {
             source,
         });
 
-        await this._loadAssets(smartFilter);
-
-        registerAnimations(smartFilter, this._renderer);
-
         return smartFilter;
-    }
-
-    /**
-     * If the SmartFilter had any assets, such as images or videos for input texture blocks,
-     * and the necessary information to rehydrate them is present in the editor data, load
-     * those assets now.
-     * @param smartFilter - The SmartFilter to load assets for
-     */
-    private async _loadAssets(smartFilter: SmartFilter): Promise<void> {
-        for (const block of smartFilter.attachedBlocks) {
-            if (block.getClassName() === "InputBlock" && (block as any).type === ConnectionPointType.Texture) {
-                const inputBlock = block as InputBlock<ConnectionPointType.Texture>;
-                await loadTextureInputBlockAsset(inputBlock, this._engine, this._renderer.beforeRenderObservable);
-            }
-        }
     }
 
     private _optimize(smartFilter: SmartFilter): SmartFilter {

--- a/packages/demo/src/smartFilterRenderer.ts
+++ b/packages/demo/src/smartFilterRenderer.ts
@@ -1,13 +1,23 @@
 import { Observable } from "@babylonjs/core/Misc/observable.js";
 import type { ThinEngine } from "@babylonjs/core/Engines/thinEngine";
 import type { Nullable } from "@babylonjs/core/types";
-import type { SmartFilter, SmartFilterRuntime } from "@babylonjs/smart-filters";
+import {
+    ConnectionPointType,
+    type InputBlock,
+    type SmartFilter,
+    type SmartFilterRuntime,
+} from "@babylonjs/smart-filters";
 import { RenderTargetGenerator } from "@babylonjs/smart-filters";
+import { loadTextureInputBlockAsset } from "@babylonjs/smart-filters-editor";
+import { registerAnimations } from "./helpers/registerAnimations";
 
 /**
  * Simple example of rendering a Smart Filter
  */
 export class SmartFilterRenderer {
+    private _assetDisposeWork: (() => void)[] = [];
+    private _animationDisposeWork: Nullable<() => void> = null;
+
     /**
      * Callback called before rendering the filter every frame.
      */
@@ -47,15 +57,20 @@ export class SmartFilterRenderer {
     public async startRendering(filter: SmartFilter, optimizeTextures = false) {
         const rtg = new RenderTargetGenerator(optimizeTextures);
         const runtime = await filter.createRuntimeAsync(this.engine, rtg);
+
+        await this._loadAssets(filter);
+        this._loadAnimations(filter);
+
         console.log("Number of render targets created: " + rtg.numTargetsCreated);
-        this.setRuntime(runtime);
+
+        this._setRuntime(runtime);
         return this.runtime;
     }
 
     /**
      * Sets the runtime to render.
      */
-    public setRuntime(runtime: SmartFilterRuntime) {
+    private _setRuntime(runtime: SmartFilterRuntime) {
         this.engine.stopRenderLoop();
 
         // Dispose the previous runtime.
@@ -72,5 +87,37 @@ export class SmartFilterRenderer {
         });
 
         this.runtime = runtime;
+    }
+
+    /**
+     * If the SmartFilter had any assets, such as images or videos for input texture blocks,
+     * and the necessary information to rehydrate them is present in the editor data, load
+     * those assets now.
+     * @param smartFilter - The SmartFilter to load assets for
+     */
+    private async _loadAssets(smartFilter: SmartFilter): Promise<void> {
+        // Dispose all previous assets
+        for (const work of this._assetDisposeWork) {
+            work();
+        }
+        this._assetDisposeWork.length = 0;
+
+        for (const block of smartFilter.attachedBlocks) {
+            if (block.getClassName() === "InputBlock" && (block as any).type === ConnectionPointType.Texture) {
+                const inputBlock = block as InputBlock<ConnectionPointType.Texture>;
+                const dispose = await loadTextureInputBlockAsset(inputBlock, this.engine, this.beforeRenderObservable);
+                if (dispose) {
+                    this._assetDisposeWork.push(dispose);
+                }
+            }
+        }
+    }
+
+    private _loadAnimations(smartFilter: SmartFilter): void {
+        if (this._animationDisposeWork) {
+            this._animationDisposeWork();
+        }
+
+        this._animationDisposeWork = registerAnimations(smartFilter, this);
     }
 }

--- a/packages/editor/src/globalState.ts
+++ b/packages/editor/src/globalState.ts
@@ -3,7 +3,7 @@ import type { ThinEngine } from "@babylonjs/core/Engines/thinEngine";
 import type { Nullable } from "@babylonjs/core/types";
 import { StateManager } from "@babylonjs/shared-ui-components/nodeGraphSystem/stateManager.js";
 import { LockObject } from "@babylonjs/shared-ui-components/tabs/propertyGrids/lockObject.js";
-import { type BaseBlock, SmartFilter, type SmartFilterRuntime } from "@babylonjs/smart-filters";
+import { type BaseBlock, SmartFilter } from "@babylonjs/smart-filters";
 import { RegisterDefaultInput } from "./graphSystem/registerDefaultInput.js";
 import { RegisterElbowSupport } from "./graphSystem/registerElbowSupport.js";
 import { RegisterNodePortDesign } from "./graphSystem/registerNodePortDesign.js";
@@ -49,8 +49,6 @@ export class GlobalState {
 
     onResetRequiredObservable = new Observable<boolean>();
 
-    onRuntimeCreatedObservable = new Observable<SmartFilterRuntime>();
-
     onSaveEditorDataRequiredObservable = new Observable<void>();
 
     texturePresets: TexturePreset[];
@@ -61,19 +59,7 @@ export class GlobalState {
 
     saveToSnippetServer?: (() => void) | undefined;
 
-    private _runtime: Nullable<SmartFilterRuntime> = null;
-    public get runtime(): Nullable<SmartFilterRuntime> {
-        return this._runtime;
-    }
-    public set runtime(value: Nullable<SmartFilterRuntime>) {
-        if (value === this._runtime) {
-            return;
-        }
-        this._runtime = value;
-        if (value) {
-            this.onRuntimeCreatedObservable.notifyObservers(value);
-        }
-    }
+    rebuildRuntime: (smartFilter: SmartFilter) => void;
 
     public constructor(
         engine: ThinEngine,
@@ -83,6 +69,7 @@ export class GlobalState {
         downloadSmartFilter: () => void,
         loadSmartFilter: (file: File) => Promise<SmartFilter>,
         beforeRenderObservable: Observable<void>,
+        rebuildRuntime: (smartFilter: SmartFilter) => void,
         saveToSnippetServer?: () => void,
         texturePresets: TexturePreset[] = []
     ) {
@@ -106,5 +93,6 @@ export class GlobalState {
         this.saveToSnippetServer = saveToSnippetServer;
         this.texturePresets = texturePresets;
         this.beforeRenderObservable = beforeRenderObservable;
+        this.rebuildRuntime = rebuildRuntime;
     }
 }

--- a/packages/editor/src/graphEditor.tsx
+++ b/packages/editor/src/graphEditor.tsx
@@ -163,21 +163,7 @@ export class GraphEditor extends react.Component<IGraphEditorProps, IGraphEditor
         );
 
         this.props.globalState.stateManager.onRebuildRequiredObservable.add(async () => {
-            if (this.props.globalState.smartFilter) {
-                // this.buildMaterial(autoConfigure);
-
-                if (this.props.globalState.runtime) {
-                    this.props.globalState.runtime.dispose();
-                }
-
-                try {
-                    this.props.globalState.runtime = await this.props.globalState.smartFilter.createRuntimeAsync(
-                        this.props.globalState.engine
-                    );
-                } catch (err: unknown) {
-                    console.error("Smart Filter could not create a runtime", err);
-                }
-            }
+            this.props.globalState.rebuildRuntime(this.props.globalState.smartFilter);
         });
 
         this.props.globalState.onSaveEditorDataRequiredObservable.add(() => {

--- a/packages/editor/src/serializationTools.ts
+++ b/packages/editor/src/serializationTools.ts
@@ -9,6 +9,7 @@ import {
 import type { GlobalState } from "./globalState";
 import type { GraphCanvasComponent } from "@babylonjs/shared-ui-components/nodeGraphSystem/graphCanvas";
 import type { Observable } from "@babylonjs/core/Misc/observable";
+import type { Nullable } from "@babylonjs/core/types";
 
 /**
  * Sets the SmartFilter's stored editor data (block locations, canvas position, zoom) using the current graph canvas state.
@@ -42,12 +43,13 @@ export function setEditorData(smartFilter: SmartFilter, globalState: GlobalState
  * @param inputBlock - The InputBlock to load the texture for
  * @param engine - The ThinEngine to create the texture with
  * @param beforeRenderObservable - Observable which is notified before rendering each frame
+ * @returns A function to dispose of the textures when they are no longer needed, or null if no textures were loaded
  */
 export async function loadTextureInputBlockAsset(
     inputBlock: InputBlock<ConnectionPointType.Texture>,
     engine: ThinEngine,
     beforeRenderObservable: Observable<void>
-): Promise<void> {
+): Promise<Nullable<() => void>> {
     const editorData = inputBlock.editorData;
 
     // Look at the editor data to determine if we can load a texture
@@ -78,6 +80,8 @@ export async function loadTextureInputBlockAsset(
                         beforeRenderObservable.remove(observer);
                         videoTexture.dispose();
                     };
+
+                    return editorData.dispose;
                 }
                 break;
             case "image":
@@ -92,10 +96,14 @@ export async function loadTextureInputBlockAsset(
                     editorData.dispose = () => {
                         texture.dispose();
                     };
+
+                    return editorData.dispose;
                 }
                 break;
         }
     }
+
+    return null;
 }
 
 export type EditorLoadedVideoTexture = {

--- a/packages/editor/src/smartFilterEditor.ts
+++ b/packages/editor/src/smartFilterEditor.ts
@@ -7,7 +7,7 @@ import { RegisterToDisplayManagers } from "./graphSystem/registerToDisplayLedger
 import { RegisterToPropertyTabManagers } from "./graphSystem/registerToPropertyLedger.js";
 import { RegisterTypeLedger } from "./graphSystem/registerToTypeLedger.js";
 import { Popup } from "./sharedComponents/popup.js";
-import type { AnyInputBlock, BaseBlock, SmartFilter, SmartFilterRuntime } from "@babylonjs/smart-filters";
+import type { AnyInputBlock, BaseBlock, SmartFilter } from "@babylonjs/smart-filters";
 import type { Nullable } from "@babylonjs/core/types.js";
 import type { Observable } from "@babylonjs/core/Misc/observable.js";
 
@@ -111,14 +111,6 @@ export type SmartFilterEditorOptions = {
     saveToSnippetServer?: () => void;
 
     /**
-     * An optional callback which is called when a new runtime is created due to the
-     * user editing the Smart Filter (beyond simply changing uniforms).
-     * It is used to allow the application to render the new runtime.
-     * @param runtime - The new runtime that was created
-     */
-    onRuntimeCreated?: (runtime: SmartFilterRuntime) => void;
-
-    /**
      * An optional array of texture presets to display in the editor.
      */
     texturePresets?: TexturePreset[];
@@ -127,6 +119,11 @@ export type SmartFilterEditorOptions = {
      * An observable that is called before rendering the filter every frame.
      */
     beforeRenderObservable: Observable<void>;
+
+    /**
+     * Called when the editor determines that the graph has changed and the runtime needs to be rebuilt.
+     */
+    rebuildRuntime: (smartFilter: SmartFilter) => void;
 };
 
 const filterEditorPopupId = "filter-editor";
@@ -164,6 +161,7 @@ export class SmartFilterEditor {
             options.downloadSmartFilter,
             options.loadSmartFilter,
             options.beforeRenderObservable,
+            options.rebuildRuntime,
             options.saveToSnippetServer,
             options.texturePresets
         );
@@ -207,10 +205,6 @@ export class SmartFilterEditor {
                     popupWindow.close();
                 }
             };
-        }
-
-        if (options.onRuntimeCreated) {
-            globalState.onRuntimeCreatedObservable.add(options.onRuntimeCreated);
         }
     }
 


### PR DESCRIPTION
- The detection of the input block directly connected to the output block special case moved from SmartFilter to OutputBlock so it can handle the case where it was but is it no longer connected directly to an input block
- SmartFilterLoader is no longer reponsible for asset & animation lifecycle, smartFilterRenderer (which already handled the runtime lifecycle) now is
- Editor no longer manages runtime recreation when you modify the graph in the editor, now its always smartFilterRenderer for simplicity
- Fixed animation lifecycle, they now dispose when you recreate the runtime
- Fixed mask shader to give expected results when you look directly at the output
- Future PR will add caching for assets that are already loaded