### PR TITLE
Add serialization / deserialization support to the WebCamInputBlock demo block

### DIFF
--- a/packages/core/src/serialization/v1/serialization.types.ts
+++ b/packages/core/src/serialization/v1/serialization.types.ts
@@ -106,3 +106,12 @@ export type DeserializeBlockV1 = (
     serializedBlock: ISerializedBlockV1,
     engine: ThinEngine
 ) => Promise<BaseBlock>;
+
+/**
+ * A function that optionally deserializes a block from a V1 serialized block object, returning null if it cannot
+ */
+export type OptionalBlockDeserializerV1 = (
+    smartFilter: SmartFilter,
+    serializedBlock: ISerializedBlockV1,
+    engine: ThinEngine
+) => Promise<Nullable<BaseBlock>>;

--- a/packages/demo/src/app.ts
+++ b/packages/demo/src/app.ts
@@ -8,7 +8,7 @@ import { SmartFilterEditor } from "@babylonjs/smart-filters-editor";
 import { createThinEngine } from "./helpers/createThinEngine";
 import { SmartFilterLoader, SmartFilterSource, type SmartFilterLoadedEvent } from "./smartFilterLoader";
 import { smartFilterManifests } from "./configuration/smartFilters";
-import { getBlockDeserializers } from "./configuration/blockDeserializers";
+import { getBlockDeserializers, inputBlockDeserializer } from "./configuration/blockDeserializers";
 import { getSnippet } from "./helpers/hashFunctions";
 import { TextureRenderHelper } from "./texureRenderHelper";
 
@@ -39,6 +39,7 @@ const smartFilterLoader = new SmartFilterLoader(
     renderer,
     smartFilterManifests,
     getBlockDeserializers(),
+    inputBlockDeserializer,
     textureRenderHelper
 );
 

--- a/packages/demo/src/configuration/blockDeserializers.ts
+++ b/packages/demo/src/configuration/blockDeserializers.ts
@@ -4,8 +4,13 @@ import {
     type DeserializeBlockV1,
     type ISerializedBlockV1,
     CopyBlock,
+    type BaseBlock,
+    createStrongRef,
 } from "@babylonjs/smart-filters";
 import { BlockNames } from "./blocks/blockNames";
+import type { Nullable } from "@babylonjs/core/types";
+import type { ThinEngine } from "@babylonjs/core/Engines/thinEngine";
+import { WebCamInputBlock, WebCamInputBlockName } from "./blocks/inputs/webCamInputBlock";
 
 /**
  * Generates the Map of block deserializers used when loaded serialized Smart Filters.
@@ -206,4 +211,15 @@ export function getBlockDeserializers(): Map<string, DeserializeBlockV1> {
     });
 
     return deserializers;
+}
+
+export async function inputBlockDeserializer(
+    smartFilter: SmartFilter,
+    serializedBlock: ISerializedBlockV1,
+    engine: ThinEngine
+): Promise<Nullable<BaseBlock>> {
+    if (serializedBlock.name === WebCamInputBlockName) {
+        return new WebCamInputBlock(smartFilter, engine, createStrongRef(null));
+    }
+    return null;
 }

--- a/packages/demo/src/configuration/blocks/inputs/webCamInputBlock.ts
+++ b/packages/demo/src/configuration/blocks/inputs/webCamInputBlock.ts
@@ -9,6 +9,8 @@ export type WebCamSource = {
     id: string;
 };
 
+export const WebCamInputBlockName = "WebCam";
+
 export class WebCamInputBlock extends InputBlock<ConnectionPointType.Texture> implements IMonitorConnectionChanges {
     private readonly _engine: ThinEngine;
     private _webCamSession: WebCamSession | undefined;
@@ -23,7 +25,7 @@ export class WebCamInputBlock extends InputBlock<ConnectionPointType.Texture> im
     >(undefined);
 
     constructor(smartFilter: SmartFilter, engine: ThinEngine, initialValue: RuntimeData<ConnectionPointType.Texture>) {
-        super(smartFilter, "WebCam", ConnectionPointType.Texture, initialValue);
+        super(smartFilter, WebCamInputBlockName, ConnectionPointType.Texture, initialValue);
         this._engine = engine;
 
         this.onWebCamSourceChanged.add(this._onWebCamSourceChanged.bind(this));

--- a/packages/demo/src/configuration/editor/blockEditorRegistrations.ts
+++ b/packages/demo/src/configuration/editor/blockEditorRegistrations.ts
@@ -26,11 +26,12 @@ import { WipeBlock } from "../blocks/transitions/wipeBlock";
 
 import type { IBlockEditorRegistration } from "./IBlockEditorRegistration";
 import { ConnectionPointType, CopyBlock, InputBlock, type SmartFilter } from "@babylonjs/smart-filters";
+import { WebCamInputBlockName } from "../blocks/inputs/webCamInputBlock";
 
 export const blockEditorRegistrations: IBlockEditorRegistration[] = [
     ...defaultBlockEditorRegistrations,
     {
-        name: "WebCam",
+        name: WebCamInputBlockName,
         category: "Inputs",
         tooltip: "Supplies a texture from a webcam",
     },

--- a/packages/demo/src/configuration/editor/createInputBlock.ts
+++ b/packages/demo/src/configuration/editor/createInputBlock.ts
@@ -1,7 +1,7 @@
 import type { Nullable } from "@babylonjs/core/types";
 import { ConnectionPointType, type BaseBlock } from "@babylonjs/smart-filters";
 import { createDefaultValue, type GlobalState } from "@babylonjs/smart-filters-editor";
-import { WebCamInputBlock } from "../blocks/inputs/webCamInputBlock";
+import { WebCamInputBlock, WebCamInputBlockName } from "../blocks/inputs/webCamInputBlock";
 
 /**
  * Intercepts the creation of an input block and can return specialized input blocks.
@@ -11,7 +11,7 @@ import { WebCamInputBlock } from "../blocks/inputs/webCamInputBlock";
  */
 export function createInputBlock(globalState: GlobalState, type: string): Nullable<BaseBlock> {
     switch (type) {
-        case "WebCam":
+        case WebCamInputBlockName:
             return new WebCamInputBlock(
                 globalState.smartFilter,
                 globalState.engine,

--- a/packages/demo/src/configuration/editor/customInputDisplayManager.ts
+++ b/packages/demo/src/configuration/editor/customInputDisplayManager.ts
@@ -1,7 +1,7 @@
 import type { INodeData } from "@babylonjs/shared-ui-components/nodeGraphSystem/interfaces/nodeData";
 import { ConnectionPointType, type AnyInputBlock } from "@babylonjs/smart-filters";
 import { InputDisplayManager } from "@babylonjs/smart-filters-editor";
-import type { WebCamInputBlock } from "../blocks/inputs/webCamInputBlock";
+import { WebCamInputBlockName, type WebCamInputBlock } from "../blocks/inputs/webCamInputBlock";
 
 /**
  * Optional override of the InputDisplayManager to provide custom display for particular blocks if desired.
@@ -13,7 +13,7 @@ export class CustomInputDisplayManager extends InputDisplayManager {
         let value = "";
         const inputBlock = nodeData.data as AnyInputBlock;
 
-        if (inputBlock.type === ConnectionPointType.Texture && inputBlock.name === "WebCam") {
+        if (inputBlock.type === ConnectionPointType.Texture && inputBlock.name === WebCamInputBlockName) {
             const webCamInputBlock = inputBlock as WebCamInputBlock;
             value = webCamInputBlock.webcamSource?.name ?? "Default";
             contentArea.innerHTML = value;

--- a/packages/demo/src/configuration/editor/getInputNodePropertyComponent.tsx
+++ b/packages/demo/src/configuration/editor/getInputNodePropertyComponent.tsx
@@ -1,6 +1,7 @@
 import { ConnectionPointType, type AnyInputBlock } from "@babylonjs/smart-filters";
 import type { GlobalState } from "@babylonjs/smart-filters-editor";
 import { WebCamInputPropertyComponent } from "./editorComponents/webCamInputPropertyComponent";
+import { WebCamInputBlockName } from "../blocks/inputs/webCamInputBlock";
 
 /**
  * If there is an InputBlock that needs special property setting UI, this function should return that UI, otherwise null.
@@ -8,7 +9,7 @@ import { WebCamInputPropertyComponent } from "./editorComponents/webCamInputProp
  * @param globalState - The global state
  */
 export function getInputNodePropertyComponent(inputBlock: AnyInputBlock, globalState: GlobalState) {
-    if (inputBlock.type === ConnectionPointType.Texture && inputBlock.name === "WebCam") {
+    if (inputBlock.type === ConnectionPointType.Texture && inputBlock.name === WebCamInputBlockName) {
         return <WebCamInputPropertyComponent inputBlock={inputBlock} globalState={globalState} />;
     }
     return null;

--- a/packages/demo/src/smartFilterLoader.ts
+++ b/packages/demo/src/smartFilterLoader.ts
@@ -4,6 +4,7 @@ import {
     type SmartFilter,
     SmartFilterDeserializer,
     type DeserializeBlockV1,
+    type OptionalBlockDeserializerV1,
 } from "@babylonjs/smart-filters";
 import type { SmartFilterRenderer } from "./smartFilterRenderer";
 import type { TextureRenderHelper } from "./texureRenderHelper";
@@ -58,6 +59,7 @@ export class SmartFilterLoader {
         renderer: SmartFilterRenderer,
         manifests: SmartFilterManifest[],
         blockDeserializers: Map<string, DeserializeBlockV1>,
+        inputBlockDeserializer: OptionalBlockDeserializerV1,
         textureRenderHelper: Nullable<TextureRenderHelper>
     ) {
         this._engine = engine;
@@ -70,7 +72,7 @@ export class SmartFilterLoader {
                 "No SmartFilterManifests were passed to the SmartFilterLoader - add some manifests to smartFilterManifests.ts"
             );
         }
-        this._deserializer = new SmartFilterDeserializer(blockDeserializers);
+        this._deserializer = new SmartFilterDeserializer(blockDeserializers, inputBlockDeserializer);
     }
 
     /**


### PR DESCRIPTION
This doesn't change the approach the demo app uses for the WebCamInputBlock - it's still just an input block with a magic name, but it does allow the deserializer to take in an optional input block deserializer which the demo app uses to create a WebCamInputBlock instead of InputBlock if it has the magic name.