### PR TITLE
Remove race condition in WebCamInputBlock initialization

### DIFF
--- a/packages/demo/src/configuration/blocks/inputs/webCamInputBlock.ts
+++ b/packages/demo/src/configuration/blocks/inputs/webCamInputBlock.ts
@@ -56,7 +56,7 @@ export class WebCamInputBlock extends InputBlock<ConnectionPointType.Texture> im
     }
 
     private async _loadOrUnloadWebCam(): Promise<void> {
-        const shouldBeLoaded = this._webCamSource !== undefined && this.output.endpoints.length > 0;
+        const shouldBeLoaded = this._webCamSource !== undefined; // && this.output.endpoints.length > 0;
         const currentWebCamSourceId = this._webCamSource?.id;
 
         if (


### PR DESCRIPTION
The check to see if the block is connected in the graph is only retriggered when changes are made in the editor. If the webcam source enumeration happens fast, then it can hit this line before the deserializer has added the connections to the graph, and it won't load.  The onConnectionsChanged() isn't called by the core or deserializer, just the editor, so it won't detect that the block got connected afterwards.

A follow up will clean this up more thoroughly.