### PR TITLE
Fix BlurBlock & Stop Override of prepareForRuntime for AggregateBlocks

### DIFF
--- a/packages/core/src/blocks/aggregateBlock.ts
+++ b/packages/core/src/blocks/aggregateBlock.ts
@@ -28,6 +28,13 @@ export abstract class AggregateBlock extends BaseBlock {
     private readonly _aggregatedInputs: [ConnectionPoint, ConnectionPoint][] = [];
 
     /**
+     * Do not override prepareForRuntime for aggregate blocks. It is not supported.
+     */
+    public override prepareForRuntime(): never {
+        throw new Error("Aggregate blocks should not be prepared for runtime.");
+    }
+
+    /**
      * @internal
      * Merges the internal graph into the SmartFilter
      */

--- a/packages/demo/src/configuration/blocks/effects/blurBlock.ts
+++ b/packages/demo/src/configuration/blocks/effects/blurBlock.ts
@@ -37,14 +37,14 @@ export class BlurBlock extends AggregateBlock {
     private readonly _finalBlurH: DirectionalBlurBlock;
 
     /**
-     * Gets much how smaller we should make the texture between the 2 consecutive bi lateral passes.
+     * Gets how much smaller we should make the texture between the 2 consecutive bi lateral passes.
      */
     public get blurTextureRatioPerPass(): number {
         return this._blurTextureRatioPerPass;
     }
 
     /**
-     * Sets much how smaller we should make the texture between the 2 consecutive bi lateral passes.
+     * Sets how much smaller we should make the texture between the 2 consecutive bi lateral passes.
      */
     public set blurTextureRatioPerPass(value: number) {
         this._blurTextureRatioPerPass = value;

--- a/packages/demo/src/configuration/blocks/effects/blurBlock.ts
+++ b/packages/demo/src/configuration/blocks/effects/blurBlock.ts
@@ -28,20 +28,49 @@ export class BlurBlock extends AggregateBlock {
      */
     public readonly output: ConnectionPoint<ConnectionPointType.Texture>;
 
-    /**
-     * Defines how smaller we should make the texture between the 2 consecutive bi lateral passes.
-     */
-    public blurTextureRatioPerPass = defaultBlurTextureRatioPerPass;
-
-    /**
-     * Defines how far the kernel might fetch the data from.
-     */
-    public blurSize = defaultBlurSize;
+    private _blurTextureRatioPerPass = defaultBlurTextureRatioPerPass;
+    private _blurSize = defaultBlurSize;
 
     private readonly _intermediateBlurV: DirectionalBlurBlock;
     private readonly _intermediateBlurH: DirectionalBlurBlock;
     private readonly _finalBlurV: DirectionalBlurBlock;
     private readonly _finalBlurH: DirectionalBlurBlock;
+
+    /**
+     * Gets how smaller we should make the texture between the 2 consecutive bi lateral passes.
+     */
+    public get blurTextureRatioPerPass(): number {
+        return this._blurTextureRatioPerPass;
+    }
+
+    /**
+     * Sets how smaller we should make the texture between the 2 consecutive bi lateral passes.
+     */
+    public set blurTextureRatioPerPass(value: number) {
+        this._blurTextureRatioPerPass = value;
+        this._intermediateBlurV.blurTextureRatio = value;
+        this._intermediateBlurH.blurTextureRatio = value;
+        this._finalBlurV.blurTextureRatio = value * value;
+        this._finalBlurH.blurTextureRatio = value * value;
+    }
+
+    /**
+     * Gets how far the kernel might fetch the data from.
+     */
+    public get blurSize(): number {
+        return this._blurSize;
+    }
+
+    /**
+     * Sets how far the kernel might fetch the data from.
+     */
+    public set blurSize(value: number) {
+        this._blurSize = value;
+        this._intermediateBlurV.blurHorizontalWidth = value;
+        this._intermediateBlurH.blurVerticalWidth = value;
+        this._finalBlurV.blurHorizontalWidth = value;
+        this._finalBlurH.blurVerticalWidth = value;
+    }
 
     /**
      * Instantiates a new Block.

--- a/packages/demo/src/configuration/blocks/effects/blurBlock.ts
+++ b/packages/demo/src/configuration/blocks/effects/blurBlock.ts
@@ -63,13 +63,7 @@ export class BlurBlock extends AggregateBlock {
 
         this.input = this._registerSubfilterInput("input", this._intermediateBlurV.input);
         this.output = this._registerSubfilterOutput("output", this._finalBlurH.output);
-    }
 
-    /**
-     * Prepares the block for runtime.
-     * This is called by the smart filter just before creating the smart filter runtime.
-     */
-    public override prepareForRuntime(): void {
         this._intermediateBlurV.blurTextureRatio = this.blurTextureRatioPerPass;
         this._intermediateBlurV.blurHorizontalWidth = this.blurSize;
         this._intermediateBlurV.blurVerticalWidth = 0;
@@ -85,7 +79,5 @@ export class BlurBlock extends AggregateBlock {
         this._finalBlurH.blurTextureRatio = this.blurTextureRatioPerPass * this.blurTextureRatioPerPass;
         this._finalBlurH.blurHorizontalWidth = 0;
         this._finalBlurH.blurVerticalWidth = this.blurSize;
-
-        super.prepareForRuntime();
     }
 }

--- a/packages/demo/src/configuration/blocks/effects/blurBlock.ts
+++ b/packages/demo/src/configuration/blocks/effects/blurBlock.ts
@@ -37,14 +37,14 @@ export class BlurBlock extends AggregateBlock {
     private readonly _finalBlurH: DirectionalBlurBlock;
 
     /**
-     * Gets how smaller we should make the texture between the 2 consecutive bi lateral passes.
+     * Gets much how smaller we should make the texture between the 2 consecutive bi lateral passes.
      */
     public get blurTextureRatioPerPass(): number {
         return this._blurTextureRatioPerPass;
     }
 
     /**
-     * Sets how smaller we should make the texture between the 2 consecutive bi lateral passes.
+     * Sets much how smaller we should make the texture between the 2 consecutive bi lateral passes.
      */
     public set blurTextureRatioPerPass(value: number) {
         this._blurTextureRatioPerPass = value;
@@ -93,20 +93,11 @@ export class BlurBlock extends AggregateBlock {
         this.input = this._registerSubfilterInput("input", this._intermediateBlurV.input);
         this.output = this._registerSubfilterOutput("output", this._finalBlurH.output);
 
-        this._intermediateBlurV.blurTextureRatio = this.blurTextureRatioPerPass;
-        this._intermediateBlurV.blurHorizontalWidth = this.blurSize;
+        this.blurSize = defaultBlurSize;
+        this.blurTextureRatioPerPass = defaultBlurTextureRatioPerPass;
         this._intermediateBlurV.blurVerticalWidth = 0;
-
-        this._intermediateBlurH.blurTextureRatio = this.blurTextureRatioPerPass;
         this._intermediateBlurH.blurHorizontalWidth = 0;
-        this._intermediateBlurH.blurVerticalWidth = this.blurSize;
-
-        this._finalBlurV.blurTextureRatio = this.blurTextureRatioPerPass * this.blurTextureRatioPerPass;
-        this._finalBlurV.blurHorizontalWidth = this.blurSize;
         this._finalBlurV.blurVerticalWidth = 0;
-
-        this._finalBlurH.blurTextureRatio = this.blurTextureRatioPerPass * this.blurTextureRatioPerPass;
         this._finalBlurH.blurHorizontalWidth = 0;
-        this._finalBlurH.blurVerticalWidth = this.blurSize;
     }
 }

--- a/packages/demo/src/configuration/blocks/effects/directionalBlurBlock.ts
+++ b/packages/demo/src/configuration/blocks/effects/directionalBlurBlock.ts
@@ -2,6 +2,7 @@ import type { Effect } from "@babylonjs/core/Materials/effect";
 
 import type { SmartFilter, IDisableableBlock, RuntimeData } from "@babylonjs/smart-filters";
 import { ShaderBlock, ConnectionPointType, ShaderBinding, injectDisableUniform } from "@babylonjs/smart-filters";
+import { BlockNames } from "../blockNames";
 
 const shaderProgram = injectDisableUniform({
     fragment: {
@@ -76,10 +77,8 @@ export class DirectionalBlurShaderBinding extends ShaderBinding {
     /**
      * Binds all the required data to the shader when rendering.
      * @param effect - defines the effect to bind the data to
-     * @param width - defines the width of the output
-     * @param height - defines the height of the output
      */
-    public override bind(effect: Effect, width: number, height: number): void {
+    public override bind(effect: Effect): void {
         super.bind(effect);
 
         // Global pass Setup
@@ -89,9 +88,12 @@ export class DirectionalBlurShaderBinding extends ShaderBinding {
         effect.setTexture(this.getRemappedName("input"), this._inputTexture.value);
 
         // Texel size
-        const texelWidth = this._blurHorizontalWidth / width;
-        const texelHeight = this._blurVerticalWidth / height;
-        effect.setFloat2(this.getRemappedName("texelStep"), texelWidth, texelHeight);
+        if (this._inputTexture.value) {
+            const inputSize = this._inputTexture.value.getSize();
+            const texelWidth = this._blurHorizontalWidth / inputSize.width;
+            const texelHeight = this._blurVerticalWidth / inputSize.height;
+            effect.setFloat2(this.getRemappedName("texelStep"), texelWidth, texelHeight);
+        }
     }
 }
 
@@ -104,7 +106,7 @@ export class DirectionalBlurBlock extends ShaderBlock {
     /**
      * The class name of the block.
      */
-    public static override ClassName = "DirectionalBlurBlock";
+    public static override ClassName = BlockNames.directionalBlur;
 
     /**
      * The input texture connection point.

--- a/packages/demo/src/configuration/blocks/effects/directionalBlurBlock.ts
+++ b/packages/demo/src/configuration/blocks/effects/directionalBlurBlock.ts
@@ -2,7 +2,6 @@ import type { Effect } from "@babylonjs/core/Materials/effect";
 
 import type { SmartFilter, IDisableableBlock, RuntimeData } from "@babylonjs/smart-filters";
 import { ShaderBlock, ConnectionPointType, ShaderBinding, injectDisableUniform } from "@babylonjs/smart-filters";
-import { BlockNames } from "../blockNames";
 
 const shaderProgram = injectDisableUniform({
     fragment: {
@@ -77,8 +76,10 @@ export class DirectionalBlurShaderBinding extends ShaderBinding {
     /**
      * Binds all the required data to the shader when rendering.
      * @param effect - defines the effect to bind the data to
+     * @param width - defines the width of the output
+     * @param height - defines the height of the output
      */
-    public override bind(effect: Effect): void {
+    public override bind(effect: Effect, width: number, height: number): void {
         super.bind(effect);
 
         // Global pass Setup
@@ -88,9 +89,8 @@ export class DirectionalBlurShaderBinding extends ShaderBinding {
         effect.setTexture(this.getRemappedName("input"), this._inputTexture.value);
 
         // Texel size
-        const inputTextureSize = this._inputTexture.value!.getSize();
-        const texelWidth = this._blurHorizontalWidth / inputTextureSize.width;
-        const texelHeight = this._blurVerticalWidth / inputTextureSize.height;
+        const texelWidth = this._blurHorizontalWidth / width;
+        const texelHeight = this._blurVerticalWidth / height;
         effect.setFloat2(this.getRemappedName("texelStep"), texelWidth, texelHeight);
     }
 }
@@ -104,7 +104,7 @@ export class DirectionalBlurBlock extends ShaderBlock {
     /**
      * The class name of the block.
      */
-    public static override ClassName = BlockNames.directionalBlur;
+    public static override ClassName = "DirectionalBlurBlock";
 
     /**
      * The input texture connection point.

--- a/packages/demo/src/configuration/blocks/effects/directionalBlurBlock.ts
+++ b/packages/demo/src/configuration/blocks/effects/directionalBlurBlock.ts
@@ -77,10 +77,8 @@ export class DirectionalBlurShaderBinding extends ShaderBinding {
     /**
      * Binds all the required data to the shader when rendering.
      * @param effect - defines the effect to bind the data to
-     * @param width - defines the width of the output
-     * @param height - defines the height of the output
      */
-    public override bind(effect: Effect, width: number, height: number): void {
+    public override bind(effect: Effect): void {
         super.bind(effect);
 
         // Global pass Setup
@@ -90,8 +88,9 @@ export class DirectionalBlurShaderBinding extends ShaderBinding {
         effect.setTexture(this.getRemappedName("input"), this._inputTexture.value);
 
         // Texel size
-        const texelWidth = this._blurHorizontalWidth / width;
-        const texelHeight = this._blurVerticalWidth / height;
+        const inputTextureSize = this._inputTexture.value!.getSize();
+        const texelWidth = this._blurHorizontalWidth / inputTextureSize.width;
+        const texelHeight = this._blurVerticalWidth / inputTextureSize.height;
         effect.setFloat2(this.getRemappedName("texelStep"), texelWidth, texelHeight);
     }
 }


### PR DESCRIPTION
The BlurBlock does not work as intended. The issue is broken into two parts:
- TexelStep was not being updated to use the correct directions/size, despite it being correctly set in BlurBlock's prepareForRuntime
- Smaller issue, but the texelStep was being decided on the render canvas' size (constant) instead of the input texture's size (can be smaller than canvas)

The first was because prepareForRuntime is never reached in AggregateBlocks. 
When the runtime is created for a SmartFilter, the workWithAggregateFreeGraph step rewires the SmartFilter in a way that essentially "removes" AggregateBlocks. Specifically, it rewires the AggregateBlock's external input/output to plug directly into the AggregateBlock's internal graph nodes. 

It would be complex to rework this wiring to include AggregateBlocks. Considering that this is the only known issue with it, and the logic of this particular AggregateBlock's prepareForRuntime can be moved elsewhere, this PR just prevents prepareForRuntime being overridden for this block type.
How? A little trick that kinda simulates C++'s `final`. If you mark the AggregateBlock's override's return as "never", then try to override that in its subclasses, you'll get errors at compile/development time.

The second issue wasn't as hard to fix :)