### PR TITLE
Fix Webcam Texture Size

### DIFF
--- a/packages/demo/src/configuration/blocks/inputs/webCamSession.ts
+++ b/packages/demo/src/configuration/blocks/inputs/webCamSession.ts
@@ -75,7 +75,6 @@ export class WebCamSession implements IDisposable {
                 false,
                 2
             );
-
             this._internalVideoTexture = internalVideoTexture;
             this._videoTexture = new ThinTexture(internalVideoTexture);
             this._textureOutput.value = this._videoTexture;

--- a/packages/demo/src/configuration/blocks/inputs/webCamSession.ts
+++ b/packages/demo/src/configuration/blocks/inputs/webCamSession.ts
@@ -64,20 +64,22 @@ export class WebCamSession implements IDisposable {
         hiddenVideo.width = width;
         hiddenVideo.height = height;
 
-        const internalVideoTexture = this._engine.createDynamicTexture(
-            hiddenVideo.videoWidth,
-            hiddenVideo.videoHeight,
-            false,
-            2
-        );
-        this._internalVideoTexture = internalVideoTexture;
-        this._videoTexture = new ThinTexture(internalVideoTexture);
-
         hiddenVideo.onerror = () => {
             throw "Failed to load WebCam";
         };
 
         hiddenVideo.onloadeddata = () => {
+            const internalVideoTexture = this._engine.createDynamicTexture(
+                hiddenVideo.videoWidth,
+                hiddenVideo.videoHeight,
+                false,
+                2
+            );
+
+            this._internalVideoTexture = internalVideoTexture;
+            this._videoTexture = new ThinTexture(internalVideoTexture);
+            this._textureOutput.value = this._videoTexture;
+
             const update = () => {
                 if (this._isDisposed) {
                     return;
@@ -94,7 +96,6 @@ export class WebCamSession implements IDisposable {
         };
 
         hiddenVideo.srcObject = stream;
-        this._textureOutput.value = this._videoTexture;
     }
 
     public dispose(): void {


### PR DESCRIPTION
Move texture initialization to be after the video element loads the video source (stream), so that the videoWidth and videoHeight of the video element are also initialized. 
That way, the dynamic texture created based off videoWidth and videoHeight has the correct size.