### PR TITLE
Add optimizer checkbox to demo UI, fix a number of optimizer compatibility issues with demo blocks

### DIFF
--- a/packages/demo/src/app.ts
+++ b/packages/demo/src/app.ts
@@ -25,11 +25,9 @@ const renderToTextureInsteadOfCanvas: boolean = false;
 // Constants
 const LocalStorageSmartFilterName = "SmartFilterName";
 const LocalStorageOptimizeName = "OptimizeSmartFilter";
-const LocalStorageEditOptimizedName = "EditOptimizedSmartFilter";
 
 // Load settings from localStorage
 let optimize: boolean = localStorage.getItem(LocalStorageOptimizeName) === "true";
-let editOptimized: boolean = localStorage.getItem(LocalStorageEditOptimizedName) === "true";
 
 // Manage our HTML elements
 const editActionLink = document.getElementById("editActionLink")!;
@@ -40,8 +38,6 @@ const snippetAndFileFooter = document.getElementById("snippetAndFileFooter")!;
 const sourceName = document.getElementById("sourceName")!;
 const version = document.getElementById("version")!;
 const optimizeCheckbox = document.getElementById("optimize") as HTMLInputElement;
-const editOptimizedCheckbox = document.getElementById("editOptimized") as HTMLInputElement;
-const editOptimizedCheckboxLabel = document.getElementById("editOptimizedLabel") as HTMLLabelElement;
 
 // Create our services
 const engine = createThinEngine(canvas);
@@ -175,14 +171,7 @@ smartFilterSelect.addEventListener("change", () => {
 editActionLink.onclick = async () => {
     if (currentSmartFilterState) {
         const module = await import(/* webpackChunkName: "smartFilterEditor" */ "./helpers/launchEditor");
-        module.launchEditor(
-            editOptimized && currentSmartFilterState.optimizedSmartFilter
-                ? currentSmartFilterState.optimizedSmartFilter
-                : currentSmartFilterState.smartFilter,
-            engine,
-            renderer,
-            smartFilterLoader
-        );
+        module.launchEditor(currentSmartFilterState.smartFilter, engine, renderer, smartFilterLoader);
     }
 };
 
@@ -191,22 +180,8 @@ optimizeCheckbox.checked = optimize;
 optimizeCheckbox.onchange = () => {
     localStorage.setItem(LocalStorageOptimizeName, optimizeCheckbox.checked.toString());
     optimize = optimizeCheckbox.checked;
-    updateEditOptimizedCheckboxVisibility();
     renderCurrentSmartFilter();
 };
-
-// Set up the edit optimized checkbox
-editOptimizedCheckbox.checked = editOptimized;
-editOptimizedCheckbox.onchange = () => {
-    localStorage.setItem(LocalStorageEditOptimizedName, editOptimizedCheckbox.checked.toString());
-    editOptimized = editOptimizedCheckbox.checked;
-    SmartFilterEditor.Hide();
-};
-function updateEditOptimizedCheckboxVisibility() {
-    editOptimizedCheckboxLabel.style.display = optimize ? "" : "none";
-    editOptimizedCheckbox.style.display = optimize ? "" : "none";
-}
-updateEditOptimizedCheckboxVisibility();
 
 // Display the current version by loading the version.json file
 fetch("./version.json").then((response: Response) => {

--- a/packages/demo/src/app.ts
+++ b/packages/demo/src/app.ts
@@ -41,6 +41,7 @@ const sourceName = document.getElementById("sourceName")!;
 const version = document.getElementById("version")!;
 const optimizeCheckbox = document.getElementById("optimize") as HTMLInputElement;
 const editOptimizedCheckbox = document.getElementById("editOptimized") as HTMLInputElement;
+const editOptimizedCheckboxLabel = document.getElementById("editOptimizedLabel") as HTMLLabelElement;
 
 // Create our services
 const engine = createThinEngine(canvas);
@@ -190,6 +191,7 @@ optimizeCheckbox.checked = optimize;
 optimizeCheckbox.onchange = () => {
     localStorage.setItem(LocalStorageOptimizeName, optimizeCheckbox.checked.toString());
     optimize = optimizeCheckbox.checked;
+    updateEditOptimizedCheckboxVisibility();
     renderCurrentSmartFilter();
 };
 
@@ -198,7 +200,13 @@ editOptimizedCheckbox.checked = editOptimized;
 editOptimizedCheckbox.onchange = () => {
     localStorage.setItem(LocalStorageEditOptimizedName, editOptimizedCheckbox.checked.toString());
     editOptimized = editOptimizedCheckbox.checked;
+    SmartFilterEditor.Hide();
 };
+function updateEditOptimizedCheckboxVisibility() {
+    editOptimizedCheckboxLabel.style.display = optimize ? "" : "none";
+    editOptimizedCheckbox.style.display = optimize ? "" : "none";
+}
+updateEditOptimizedCheckboxVisibility();
 
 // Display the current version by loading the version.json file
 fetch("./version.json").then((response: Response) => {

--- a/packages/demo/src/app.ts
+++ b/packages/demo/src/app.ts
@@ -17,7 +17,10 @@ const useTextureAnalyzer: boolean = false;
 const renderToTextureInsteadOfCanvas: boolean = false;
 
 // TODO: add UI for toggling between regular and optimized graphs
-const optimize: boolean = true;
+const optimize: boolean = false;
+
+// Repro of different results: http://localhost:8080/#UDAV8T#53
+// Repro of hang: http://localhost:8080/#UDAV8T#45
 
 // Constants
 const LocalStorageSmartFilterName = "SmartFilterName";

--- a/packages/demo/src/app.ts
+++ b/packages/demo/src/app.ts
@@ -19,7 +19,6 @@ type CurrentSmartFilterState = {
 };
 
 // Hardcoded options there is no UI for
-const useTextureAnalyzer: boolean = false;
 const renderToTextureInsteadOfCanvas: boolean = false;
 
 // Constants
@@ -73,7 +72,7 @@ function renderCurrentSmartFilter() {
     console.log(`Rendering SmartFilter "${smartFilterState.smartFilter.name}"`, optimize ? "[optimized]" : "");
 
     renderer
-        .startRendering(smartFilterState.smartFilter, optimize, useTextureAnalyzer)
+        .startRendering(smartFilterState.smartFilter, optimize, optimize)
         .then((smartFilterRendered: SmartFilter) => {
             if (optimize) {
                 smartFilterState.optimizedSmartFilter = smartFilterRendered;

--- a/packages/demo/src/app.ts
+++ b/packages/demo/src/app.ts
@@ -17,7 +17,7 @@ const useTextureAnalyzer: boolean = false;
 const renderToTextureInsteadOfCanvas: boolean = false;
 
 // TODO: add UI for toggling between regular and optimized graphs
-const optimize: boolean = false;
+const optimize: boolean = true;
 
 // Constants
 const LocalStorageSmartFilterName = "SmartFilterName";
@@ -58,7 +58,7 @@ if (textureRenderHelper) {
 smartFilterLoader.onSmartFilterLoadedObservable.add((event: SmartFilterLoadedEvent) => {
     SmartFilterEditor.Hide();
     currentSmartFilter = event.smartFilter;
-    renderer.startRendering(currentSmartFilter, useTextureAnalyzer).catch((err: unknown) => {
+    renderer.startRendering(currentSmartFilter, optimize, useTextureAnalyzer).catch((err: unknown) => {
         console.error("Could not start rendering", err);
     });
 
@@ -103,11 +103,11 @@ async function checkHash() {
     if (snippetToken) {
         // Reset hash with our formatting to keep it looking consistent
         setSnippet(snippetToken, version, false);
-        smartFilterLoader.loadFromSnippet(snippetToken, version, optimize);
+        smartFilterLoader.loadFromSnippet(snippetToken, version);
     } else {
         const smartFilterName =
             localStorage.getItem(LocalStorageSmartFilterName) || smartFilterLoader.defaultSmartFilterName;
-        smartFilterLoader.loadFromManifest(smartFilterName, optimize);
+        smartFilterLoader.loadFromManifest(smartFilterName);
     }
 }
 
@@ -127,7 +127,7 @@ smartFilterLoader.manifests.forEach((manifest) => {
 // Set up SmartFilter <select> handler
 smartFilterSelect.addEventListener("change", () => {
     localStorage.setItem(LocalStorageSmartFilterName, smartFilterSelect.value);
-    smartFilterLoader.loadFromManifest(smartFilterSelect.value, optimize);
+    smartFilterLoader.loadFromManifest(smartFilterSelect.value);
 });
 
 // Set up editor button

--- a/packages/demo/src/app.ts
+++ b/packages/demo/src/app.ts
@@ -100,23 +100,27 @@ smartFilterLoader.onSmartFilterLoadedObservable.add((event: SmartFilterLoadedEve
  * Checks the hash for a snippet token and loads the SmartFilter if one is found.
  * Otherwise, loads the last in-repo SmartFilter or the default.
  */
-async function checkHash() {
+async function loadFromHash() {
     const [snippetToken, version] = getSnippet();
 
-    if (snippetToken) {
-        // Reset hash with our formatting to keep it looking consistent
-        setSnippet(snippetToken, version, false);
-        smartFilterLoader.loadFromSnippet(snippetToken, version);
-    } else {
-        const smartFilterName =
-            localStorage.getItem(LocalStorageSmartFilterName) || smartFilterLoader.defaultSmartFilterName;
-        smartFilterLoader.loadFromManifest(smartFilterName);
+    try {
+        if (snippetToken) {
+            // Reset hash with our formatting to keep it looking consistent
+            setSnippet(snippetToken, version, false);
+            smartFilterLoader.loadFromSnippet(snippetToken, version);
+        } else {
+            const smartFilterName =
+                localStorage.getItem(LocalStorageSmartFilterName) || smartFilterLoader.defaultSmartFilterName;
+            smartFilterLoader.loadFromManifest(smartFilterName);
+        }
+    } catch (e) {
+        smartFilterLoader.loadFromManifest(smartFilterLoader.defaultSmartFilterName);
     }
 }
 
 // Initial load and hashchange listener
-checkHash();
-window.addEventListener("hashchange", checkHash);
+loadFromHash();
+window.addEventListener("hashchange", loadFromHash);
 
 // Populate the smart filter <select> list
 smartFilterLoader.manifests.forEach((manifest) => {
@@ -130,7 +134,11 @@ smartFilterLoader.manifests.forEach((manifest) => {
 // Set up SmartFilter <select> handler
 smartFilterSelect.addEventListener("change", () => {
     localStorage.setItem(LocalStorageSmartFilterName, smartFilterSelect.value);
-    smartFilterLoader.loadFromManifest(smartFilterSelect.value);
+    try {
+        smartFilterLoader.loadFromManifest(smartFilterSelect.value);
+    } catch (e) {
+        smartFilterLoader.loadFromManifest(smartFilterLoader.defaultSmartFilterName);
+    }
 });
 
 // Set up editor button

--- a/packages/demo/src/configuration/blocks/effects/compositionBlock.ts
+++ b/packages/demo/src/configuration/blocks/effects/compositionBlock.ts
@@ -246,7 +246,7 @@ export class CompositionBlock extends ShaderBlock {
      * @param name - The friendly name of the block
      */
     constructor(smartFilter: SmartFilter, name: string) {
-        super(smartFilter, name);
+        super(smartFilter, name, true);
     }
 
     /**

--- a/packages/demo/src/configuration/blocks/effects/compositionBlock.ts
+++ b/packages/demo/src/configuration/blocks/effects/compositionBlock.ts
@@ -147,11 +147,12 @@ export class CompositionShaderBinding extends ShaderBinding {
         effect.setTexture(this.getRemappedName("background"), background);
         effect.setTexture(this.getRemappedName("foreground"), foreground);
 
-        if (foreground) {
-            effect.setFloat2(this.getRemappedName("scaleUV"), foregroundWidth, foregroundHeight);
-            effect.setFloat2(this.getRemappedName("translateUV"), -1 * foregroundLeft, foregroundTop);
-            effect.setFloat(this.getRemappedName("foregroundAlphaScale"), foregroundAlphaScale);
-        }
+        // NOTE: textures may always be undefined if connected to another shader block when the graph is optimized
+        // TODO: consider ways to make the mistake of assuming it'll be defined less likely
+
+        effect.setFloat2(this.getRemappedName("scaleUV"), foregroundWidth, foregroundHeight);
+        effect.setFloat2(this.getRemappedName("translateUV"), -1 * foregroundLeft, foregroundTop);
+        effect.setFloat(this.getRemappedName("foregroundAlphaScale"), foregroundAlphaScale);
     }
 }
 

--- a/packages/demo/src/configuration/blocks/effects/compositionBlock.ts
+++ b/packages/demo/src/configuration/blocks/effects/compositionBlock.ts
@@ -147,7 +147,6 @@ export class CompositionShaderBinding extends ShaderBinding {
         effect.setTexture(this.getRemappedName("foreground"), foreground);
 
         // NOTE: textures may always be undefined if connected to another shader block when the graph is optimized
-        // TODO: consider ways to make the mistake of assuming it'll be defined less likely
 
         effect.setFloat2(this.getRemappedName("scaleUV"), foregroundWidth, foregroundHeight);
         effect.setFloat2(this.getRemappedName("translateUV"), -1 * foregroundLeft, foregroundTop);

--- a/packages/demo/src/configuration/blocks/effects/maskBlock.fragment.glsl
+++ b/packages/demo/src/configuration/blocks/effects/maskBlock.fragment.glsl
@@ -1,9 +1,9 @@
 uniform sampler2D input; // main
-uniform sampler2D maskTexture;
+uniform sampler2D mask;
 
 vec4 maskBlock(vec2 vUV) { // main
     vec3 color = texture2D(input, vUV).rgb;
-    vec3 maskColor = texture2D(maskTexture, vUV).rgb;
+    vec3 maskColor = texture2D(mask, vUV).rgb;
     float luminance = dot(maskColor, vec3(0.3, 0.59, 0.11));
 
     return vec4(color * luminance, luminance);

--- a/packages/demo/src/configuration/blocks/effects/maskBlock.ts
+++ b/packages/demo/src/configuration/blocks/effects/maskBlock.ts
@@ -35,7 +35,7 @@ export class MaskShaderBinding extends ShaderBinding {
     public override bind(effect: Effect): void {
         super.bind(effect);
         effect.setTexture(this.getRemappedName(uniforms.input), this._inputTexture.value);
-        effect.setTexture(this.getRemappedName(uniforms.maskTexture), this._maskTexture.value);
+        effect.setTexture(this.getRemappedName(uniforms.mask), this._maskTexture.value);
     }
 }
 

--- a/packages/demo/src/configuration/blocks/generators/auroraBlock.ts
+++ b/packages/demo/src/configuration/blocks/generators/auroraBlock.ts
@@ -73,7 +73,7 @@ export class AuroraBlock extends ShaderBlock {
      * @param name - The friendly name of the block
      */
     constructor(smartFilter: SmartFilter, name: string) {
-        super(smartFilter, name);
+        super(smartFilter, name, true);
     }
 
     /**

--- a/packages/demo/src/configuration/blocks/generators/fireworksBlock.ts
+++ b/packages/demo/src/configuration/blocks/generators/fireworksBlock.ts
@@ -53,7 +53,7 @@ export class FireworksShaderBinding extends ShaderBinding {
 }
 
 /**
- * A block that adds a fireworks effect overlayed on the input texture.
+ * A block that adds a fireworks effect overlaid on the input texture.
  */
 export class FireworksBlock extends ShaderBlock {
     /**
@@ -100,7 +100,7 @@ export class FireworksBlock extends ShaderBlock {
      * @param name - The friendly name of the block
      */
     constructor(smartFilter: SmartFilter, name: string) {
-        super(smartFilter, name);
+        super(smartFilter, name, true);
     }
 
     /**

--- a/packages/demo/src/configuration/blocks/generators/particleBlock.ts
+++ b/packages/demo/src/configuration/blocks/generators/particleBlock.ts
@@ -144,7 +144,7 @@ export class ParticleBlock extends ShaderBlock {
      * @param name - The friendly name of the block
      */
     constructor(smartFilter: SmartFilter, name: string) {
-        super(smartFilter, name);
+        super(smartFilter, name, true);
     }
 
     /**

--- a/packages/demo/src/configuration/blocks/inputs/webCamInputBlock.ts
+++ b/packages/demo/src/configuration/blocks/inputs/webCamInputBlock.ts
@@ -58,13 +58,17 @@ export class WebCamInputBlock extends InputBlock<ConnectionPointType.Texture> {
             }));
     }
 
+    public initializeWebCamRuntime(): WebCamRuntime {
+        this._webCamRuntime = new WebCamRuntime(this._engine, this.runtimeValue);
+        this._webCamRuntime.deviceId = this._webCamSource.id;
+        return this._webCamRuntime;
+    }
+
     public override generateCommandsAndGatherInitPromises(
         initializationData: InitializationData,
         _finalOutput: boolean
     ): void {
-        this._webCamRuntime = new WebCamRuntime(this._engine, this.runtimeValue);
-        this._webCamRuntime.deviceId = this._webCamSource.id;
-        initializationData.disposableResources.push(this._webCamRuntime);
+        initializationData.disposableResources.push(this.initializeWebCamRuntime());
     }
 
     private async _onWebCamSourceChanged(webCamSource: WebCamSource): Promise<void> {

--- a/packages/demo/src/configuration/blocks/inputs/webCamSession.ts
+++ b/packages/demo/src/configuration/blocks/inputs/webCamSession.ts
@@ -77,6 +77,8 @@ export class WebCamSession implements IDisposable {
             );
             this._internalVideoTexture = internalVideoTexture;
             this._videoTexture = new ThinTexture(internalVideoTexture);
+            this._videoTexture.wrapU = 0;
+            this._videoTexture.wrapV = 0;
             this._textureOutput.value = this._videoTexture;
 
             const update = () => {

--- a/packages/demo/src/configuration/smartFilters/hardCoded/simpleLogo.ts
+++ b/packages/demo/src/configuration/smartFilters/hardCoded/simpleLogo.ts
@@ -9,6 +9,7 @@ import {
 import { HardCodedSmartFilterNames } from "./hardCodedSmartFilterNames";
 import { BlackAndWhiteBlock } from "../../blocks/effects/blackAndWhiteBlock";
 import { PixelateBlock } from "../../blocks/effects/pixelateBlock";
+import { PremultiplyAlphaBlock } from "../../blocks/utility/premultiplyAlphaBlock";
 
 export function createSimpleLogoSmartFilter(engine: ThinEngine): SmartFilter {
     const smartFilter = new SmartFilter(HardCodedSmartFilterNames.simpleLogo);
@@ -17,11 +18,13 @@ export function createSimpleLogoSmartFilter(engine: ThinEngine): SmartFilter {
     const blackAndWhite = new BlackAndWhiteBlock(smartFilter, "blackAndWhite");
     const pixelate = new PixelateBlock(smartFilter, "pixelate");
     const pixelateIntensity = new InputBlock(smartFilter, "intensity", ConnectionPointType.Float, 0.4);
+    const premultiplyAlpha = new PremultiplyAlphaBlock(smartFilter, "premultiplyAlpha");
 
     logoInput.output.connectTo(blackAndWhite.input);
     blackAndWhite.output.connectTo(pixelate.input);
     pixelateIntensity.output.connectTo(pixelate.intensity);
-    pixelate.output.connectTo(smartFilter.output);
+    pixelate.output.connectTo(premultiplyAlpha.input);
+    premultiplyAlpha.output.connectTo(smartFilter.output);
 
     return smartFilter;
 }

--- a/packages/demo/src/helpers/launchEditor.ts
+++ b/packages/demo/src/helpers/launchEditor.ts
@@ -85,7 +85,7 @@ export function launchEditor(
                 );
             },
             loadSmartFilter: async (file: File) => {
-                return smartFilterLoader.loadFromFile(file, false); // TODO: update optimize
+                return smartFilterLoader.loadFromFile(file);
             },
             saveToSnippetServer: async () => {
                 const serializer = new SmartFilterSerializer(

--- a/packages/demo/src/smartFilterLoader.ts
+++ b/packages/demo/src/smartFilterLoader.ts
@@ -80,7 +80,9 @@ export class SmartFilterLoader {
      */
     public async loadFromManifest(name: string): Promise<SmartFilter> {
         return this._loadSmartFilter(async () => {
-            const manifest = this.manifests.find((manifest) => manifest.name === name);
+            const manifest = this.manifests.find(
+                (manifest) => manifest.name === name || manifest.name + " - optimized" === name
+            );
             switch (manifest?.type) {
                 case "HardCoded": {
                     return manifest.createSmartFilter(this._engine, this._renderer);

--- a/packages/demo/src/smartFilterRenderer.ts
+++ b/packages/demo/src/smartFilterRenderer.ts
@@ -71,7 +71,8 @@ export class SmartFilterRenderer {
         console.log("Number of render targets created: " + rtg.numTargetsCreated);
 
         this._setRuntime(runtime);
-        return this.runtime;
+
+        return filterToRender;
     }
 
     /**

--- a/packages/demo/www/index.html
+++ b/packages/demo/www/index.html
@@ -28,18 +28,17 @@
                 margin: auto;
                 border: none !important;
                 outline: none !important;
-                background: conic-gradient(
-                    #cccccc 90deg,
-                    #ffffff 90deg 180deg,
-                    #cccccc 180deg 270deg,
-                    #ffffff 270deg
-                );
+                background: conic-gradient(#cccccc 90deg, #ffffff 90deg 180deg, #cccccc 180deg 270deg, #ffffff 270deg);
                 background-repeat: repeat;
                 background-size: 100px 100px;
                 background-position: top left;
             }
 
-            .footer div {
+            .footer .center {
+                grid-column: 2;
+            }
+
+            .footer .center div {
                 display: none;
             }
 
@@ -98,6 +97,8 @@
                 grid-column-end: 5;
                 grid-row-start: 3;
                 grid-row-end: 3;
+                display: grid;
+                grid-template-columns: 1fr auto 1fr;
             }
 
             .versionLine {
@@ -145,6 +146,17 @@
                 margin-block: 0;
                 line-height: normal;
             }
+
+            .footer #options {
+                text-align: right;
+                margin-right: 10px;
+                vertical-align: top;
+                line-height: normal;
+                display: flex;
+                flex-direction: row;
+                justify-content: flex-end;
+                align-items: flex-start;
+            }
         </style>
     </head>
 
@@ -165,21 +177,28 @@
                 <canvas id="renderCanvas" width="1024" height="700"></canvas>
             </div>
             <div class="footer">
-                <div id="inRepoFooter">
+                <div class="center">
+                    <div id="inRepoSelection">
+                        <p>
+                            SmartFilter:
+                            <select id="smartFilterSelect" title="SmartFilter"></select>
+                        </p>
+                        <p>To modify this list, see smartFilters.ts</p>
+                    </div>
+                    <div id="snippetAndFileFooter">
+                        <p>Viewing SmartFilter from <b id="sourceName">snippet server or local file</b>.</p>
+                        <p>To browse in-repo SmartFilters, reload the page with an empty hash.</p>
+                    </div>
                     <p>
-                        SmartFilter:
-                        <select id="smartFilterSelect" title="SmartFilter"></select>
+                        The source for this preview tool can be found
+                        <a href="https://github.com/BabylonJS/SmartFilters/tree/main/packages/demo">here</a>.
                     </p>
-                    <p>To modify this list, see smartFilters.ts</p>
                 </div>
-                <div id="snippetAndFileFooter">
-                    <p>Viewing SmartFilter from <b id="sourceName">snippet server or local file</b>.</p>
-                    <p>To browse in-repo SmartFilters, reload the page with an empty hash.</p>
+                <div id="options">
+                    <div>
+                        <input type="checkbox" id="optimize" title="Optimize">Optimize</input>
+                    </div>
                 </div>
-                <p>
-                    The source for this preview tool can be found
-                    <a href="https://github.com/BabylonJS/SmartFilters/tree/main/packages/demo">here</a>.
-                </p>
             </div>
             <div class="versionLine">
                 <div class="version" id="version"></div>

--- a/packages/demo/www/index.html
+++ b/packages/demo/www/index.html
@@ -155,6 +155,11 @@
                 display: flex;
                 flex-direction: column;
             }
+            #options label {
+                cursor: pointer;
+                -webkit-user-select: none;
+                user-select: none;
+            }
         </style>
     </head>
 
@@ -194,10 +199,12 @@
                 </div>
                 <div id="options">
                     <div>
-                        <input type="checkbox" id="optimize" title="Optimize">Optimize</input>
+                        <label><input type="checkbox" id="optimize" title="Optimize" />Optimize</label>
                     </div>
                     <div>
-                        <input type="checkbox" id="editOptimized" title="Edit Optimized">Edit Optimized</input>
+                        <label id="editOptimizedLabel"
+                            ><input type="checkbox" id="editOptimized" title="Edit Optimized" />Edit Optimized</label
+                        >
                     </div>
                 </div>
             </div>

--- a/packages/demo/www/index.html
+++ b/packages/demo/www/index.html
@@ -201,11 +201,6 @@
                     <div>
                         <label><input type="checkbox" id="optimize" title="Optimize" />Optimize</label>
                     </div>
-                    <div>
-                        <label id="editOptimizedLabel"
-                            ><input type="checkbox" id="editOptimized" title="Edit Optimized" />Edit Optimized</label
-                        >
-                    </div>
                 </div>
             </div>
             <div class="versionLine">

--- a/packages/demo/www/index.html
+++ b/packages/demo/www/index.html
@@ -153,9 +153,7 @@
                 vertical-align: top;
                 line-height: normal;
                 display: flex;
-                flex-direction: row;
-                justify-content: flex-end;
-                align-items: flex-start;
+                flex-direction: column;
             }
         </style>
     </head>
@@ -197,6 +195,9 @@
                 <div id="options">
                     <div>
                         <input type="checkbox" id="optimize" title="Optimize">Optimize</input>
+                    </div>
+                    <div>
+                        <input type="checkbox" id="editOptimized" title="Edit Optimized">Edit Optimized</input>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fixed demo block incompatibilities with the optimizer, such as mismatched uniform / connection point names, and conditionals in the bind function. Backlog items have been created to add tooling / conventions to make these mistakes harder to make.

Marked a few demo blocks as unoptimizable since they contain too much branching to be merged into a large shader.

Added an optimizer checkbox in the demo app UI to toggle the optimizer on / off, as well as an option for viewing the optimized or unoptimized graph in the editor.

Added the PremultiplyAlphaBlock to the default graph to get the correct output.

Moved the optimizer step from the demo loader to the demo renderer to make it easy to toggle back and forth without reloading.

Modified the demo animation code to enable the webcam block to work in optimized graphs.