### PR TITLE
Add error display to demo app, make it an error to not connect the OutputBlock, fix React warning

### DIFF
--- a/packages/core/src/blocks/outputBlock.ts
+++ b/packages/core/src/blocks/outputBlock.ts
@@ -61,6 +61,7 @@ export class OutputBlock extends BaseBlock {
                 block.propagateRuntimeData();
             }
         });
+        this._confirmRuntimeDataSupplied(this.input);
     }
 
     /**

--- a/packages/demo/src/helpers/launchEditor.ts
+++ b/packages/demo/src/helpers/launchEditor.ts
@@ -24,7 +24,9 @@ export function launchEditor(
     currentSmartFilter: SmartFilter,
     engine: ThinEngine,
     renderer: SmartFilterRenderer,
-    smartFilterLoader: SmartFilterLoader
+    smartFilterLoader: SmartFilterLoader,
+    errorHandler: (message: string) => void,
+    closeError: () => void
 ) {
     // Set up block registration
     const blockTooltips: { [key: string]: string } = {};
@@ -61,13 +63,16 @@ export function launchEditor(
             blockRegistration,
             filter: currentSmartFilter,
             rebuildRuntime: (smartFilter: SmartFilter) => {
-                renderer.startRendering(smartFilter).catch((err: unknown) => {
-                    console.error("Could not start rendering", err);
-                });
+                renderer
+                    .startRendering(smartFilter)
+                    .then(closeError)
+                    .catch((err: unknown) => {
+                        errorHandler(`Could not start rendering\n${err}`);
+                    });
             },
             reloadAssets: (smartFilter: SmartFilter) => {
                 renderer.loadAssets(smartFilter).catch((err: unknown) => {
-                    console.error("Could not reload assets", err);
+                    errorHandler(`Could not reload assets:\n${err}`);
                 });
             },
             downloadSmartFilter: () => {

--- a/packages/demo/www/index.html
+++ b/packages/demo/www/index.html
@@ -34,6 +34,46 @@
                 background-position: top left;
             }
 
+            #errorContainer {
+                grid-column-start: 2;
+                grid-column-end: 5;
+                grid-row-start: 2;
+                grid-row-end: 2;
+                background-color: #ff000040;
+                display: none;
+            }
+
+            #errorBox {
+                border: 1px solid black;
+                border-radius: 4px;
+                background-color: white;
+                color: black;
+                margin: 20px;
+                padding: 10px;
+            }
+
+            #errorHeader {
+                display: flex;
+                justify-content: space-between;
+                border-bottom: 1px solid black;
+                padding-bottom: 4px;
+            }
+
+            #errorCloseButton {
+                width: 25px;
+                height: 25px;
+            }
+
+            #errorTitle {
+                font-size: 20px;
+                font-weight: bold;
+                margin-bottom: 4px;
+            }
+
+            #errorMessage {
+                white-space: pre-line;
+            }
+
             .footer .center {
                 grid-column: 2;
             }
@@ -178,6 +218,15 @@
             </div>
             <div class="content" id="container" width="1024" height="700">
                 <canvas id="renderCanvas" width="1024" height="700"></canvas>
+            </div>
+            <div id="errorContainer">
+                <div id="errorBox">
+                    <div id="errorHeader">
+                        <div id="errorTitle">Error</div>
+                        <button id="errorCloseButton">X</button>
+                    </div>
+                    <div id="errorMessage"></div>
+                </div>
             </div>
             <div class="footer">
                 <div class="center">

--- a/packages/editor/src/components/propertyTab/inputsPropertyTabComponent.tsx
+++ b/packages/editor/src/components/propertyTab/inputsPropertyTabComponent.tsx
@@ -56,6 +56,7 @@ export class InputsPropertyTabComponent extends react.Component<IInputsPropertyT
             case ConnectionPointType.Float: {
                 return (
                     <FloatSliderComponent
+                        key={block.uniqueId}
                         lockObject={this.props.lockObject}
                         label={block.name}
                         target={block.runtimeValue}


### PR DESCRIPTION
This makes it easier to build Smart Filters in the Editor without having the devtools open - errors now clearly show up in the preview.

This also makes it an error if the output block is not connected to the graph.

It also fixes a React warning about a missing key.