### PR TITLE
Fix default input value custom aggregate blocks

### DIFF
--- a/packages/core/src/blocks/aggregateBlock.ts
+++ b/packages/core/src/blocks/aggregateBlock.ts
@@ -57,6 +57,15 @@ export abstract class AggregateBlock extends BaseBlock {
                 for (const internalConnectionPoint of internalConnectionPoints) {
                     connectedToExternalConnectionPoint.connectTo(internalConnectionPoint);
                 }
+            } else {
+                // If the external connection point is not connected to anything but has a default value,
+                // pass that default value along to the internal connection points it is associated with
+                const defaultValue = externalConnectionPoint.runtimeData;
+                if (defaultValue !== null) {
+                    for (const internalConnectionPoint of internalConnectionPoints) {
+                        internalConnectionPoint.runtimeData = defaultValue;
+                    }
+                }
             }
         }
 

--- a/packages/core/src/connection/connectionPoint.ts
+++ b/packages/core/src/connection/connectionPoint.ts
@@ -89,7 +89,7 @@ export class ConnectionPoint<U extends ConnectionPointType = ConnectionPointType
     }
 
     /**
-     * @returns the connection point this connection point is connected to.
+     * @returns The connection point this connection point is connected to.
      * (the one on the other side of the connection)
      * Only input connection points have a connected point which they received their value from.
      * (Relation is always 1:N for input:output)
@@ -99,8 +99,8 @@ export class ConnectionPoint<U extends ConnectionPointType = ConnectionPointType
     }
 
     /**
-     * @returns the connection point this connection point is to.
-     * (the one on the other side of the connection)
+     * @returns The connection points this output connection point is connected to.
+     * (the ones on the other side of the connection)
      * Only output connection points have a list of endpoints which they provide their value to.
      * (Relation is always 1:N for input:output)
      */


### PR DESCRIPTION
If an input connection point on a custom aggregate block is not connected, the default value was not being respected.