### PR TITLE
Fix texture input preview, remove unused devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12895,12 +12895,6 @@
                 "wbuf": "^1.7.3"
             }
         },
-        "node_modules/split.js": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/split.js/-/split.js-1.6.5.tgz",
-            "integrity": "sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw==",
-            "dev": true
-        },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -14830,7 +14824,6 @@
                 "sass": "^1.85.0",
                 "sass-loader": "^16.0.5",
                 "source-map-loader": "^3.0.0",
-                "split.js": "^1.6.5",
                 "style-loader": "^3.3.0",
                 "ts-loader": "^9.4.1",
                 "url-loader": "^4.1.1",
@@ -14874,7 +14867,6 @@
                 "react-dom": "^17.0.2",
                 "sass-loader": "^13.0.2",
                 "source-map-loader": "^3.0.0",
-                "split.js": "^1.6.5",
                 "style-loader": "^3.3.0",
                 "ts-loader": "^9.4.1",
                 "url-loader": "^4.1.1",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -40,7 +40,6 @@
         "sass": "^1.85.0",
         "sass-loader": "^16.0.5",
         "source-map-loader": "^3.0.0",
-        "split.js": "^1.6.5",
         "style-loader": "^3.3.0",
         "ts-loader": "^9.4.1",
         "url-loader": "^4.1.1",

--- a/packages/editor/src/assets/styles/main.scss
+++ b/packages/editor/src/assets/styles/main.scss
@@ -59,6 +59,11 @@
             width: 100%;
             height: 100%;
         }
+
+        .texture-input-preview {
+            aspect-ratio: 16 / 9;
+            object-fit: contain;
+        }
     }
 
     .right-panel {

--- a/packages/editor/src/graphSystem/display/inputDisplayManager.ts
+++ b/packages/editor/src/graphSystem/display/inputDisplayManager.ts
@@ -84,7 +84,7 @@ export class InputDisplayManager implements IDisplayManager {
                             ? "transform: scaleY(-1); z-index: -1;"
                             : "";
                     const src = inputBlock.editorData?.url || inputBlock.runtimeValue.value?.getInternalTexture()?.url;
-                    value = src ? `<img src="${src}" style="${style}"/>` : "";
+                    value = src ? `<img src="${src}" style="${style}" class="texture-input-preview"/>` : "";
                 }
                 break;
             }

--- a/packages/sfe/package.json
+++ b/packages/sfe/package.json
@@ -40,7 +40,6 @@
         "node-sass": "^9.0.0",
         "sass-loader": "^13.0.2",
         "source-map-loader": "^3.0.0",
-        "split.js": "^1.6.5",
         "style-loader": "^3.3.0",
         "ts-loader": "^9.4.1",
         "url-loader": "^4.1.1",


### PR DESCRIPTION
The texture input block preview will no longer grow with the content of the image, so now the block layout code can correctly ensure that the blocks don't overlap without a race condition with the image load.