### PR TITLE
Fix SFE behavior after custom block replace

### DIFF
--- a/packages/editor/src/globalState.ts
+++ b/packages/editor/src/globalState.ts
@@ -59,7 +59,7 @@ export class GlobalState {
 
     onPreviewResetRequiredObservable = new Observable<void>();
 
-    onSaveEditorDataRequiredObservable = new Observable<void>();
+    onSaveEditorDataRequiredObservable: Observable<void>;
 
     texturePresets: TexturePreset[];
 
@@ -102,7 +102,8 @@ export class GlobalState {
         texturePresets: TexturePreset[] = [],
         addCustomBlock?: (serializedData: string) => void,
         deleteCustomBlock?: (blockRegistration: IBlockRegistration) => void,
-        onLogRequiredObservable?: Observable<LogEntry>
+        onLogRequiredObservable?: Observable<LogEntry>,
+        onSaveEditorDataRequiredObservable?: Observable<void>
     ) {
         this.stateManager = new StateManager();
         this.stateManager.data = this;
@@ -132,6 +133,7 @@ export class GlobalState {
         this.deleteCustomBlock = deleteCustomBlock;
 
         this.onLogRequiredObservable = onLogRequiredObservable ?? new Observable<LogEntry>();
+        this.onSaveEditorDataRequiredObservable = onSaveEditorDataRequiredObservable ?? new Observable<void>();
 
         this._previewBackground = localStorage.getItem(PreviewBackgroundStorageKey) ?? "grid";
     }

--- a/packages/editor/src/smartFilterEditorControl.ts
+++ b/packages/editor/src/smartFilterEditorControl.ts
@@ -110,6 +110,11 @@ export type SmartFilterEditorOptions = {
      * An observable that is called when the editor needs to log a message
      */
     onLogRequiredObservable?: Observable<LogEntry>;
+
+    /**
+     * An observable that is called when the editor needs to save editorData to the current Smart Filter
+     */
+    onSaveEditorDataRequiredObservable?: Observable<void>;
 };
 
 /**
@@ -157,7 +162,8 @@ export class SmartFilterEditorControl {
             options.texturePresets,
             options.addCustomBlock,
             options.deleteCustomBlock,
-            options.onLogRequiredObservable
+            options.onLogRequiredObservable,
+            options.onSaveEditorDataRequiredObservable
         );
 
         RegisterToDisplayManagers(globalState);

--- a/packages/sfe/src/app.ts
+++ b/packages/sfe/src/app.ts
@@ -48,6 +48,7 @@ async function main(): Promise<void> {
     let currentSmartFilter: Nullable<SmartFilter> = null;
     let renderer: Nullable<SmartFilterRenderer> = null;
     const onSmartFilterLoadedObservable = new Observable<SmartFilter>();
+    const onSaveEditorDataRequiredObservable = new Observable<void>();
     let afterEngineResizerObserver: Nullable<Observer<ThinEngine>> = null;
     const onLogRequiredObservable = new Observable<LogEntry>();
     let engine: Nullable<ThinEngine> = null;
@@ -219,11 +220,13 @@ async function main(): Promise<void> {
 
                 // Rebuild the current Smart Filter in case this block was used in it
                 if (engine && currentSmartFilter) {
+                    onSaveEditorDataRequiredObservable.notifyObservers();
                     const serializedSmartFilter = await serializeSmartFilter(currentSmartFilter);
                     currentSmartFilter = await smartFilterDeserializer.deserialize(
                         engine,
                         JSON.parse(serializedSmartFilter)
                     );
+                    onSmartFilterLoadedObservable.notifyObservers(currentSmartFilter);
                 }
                 startRendering();
             } catch (err) {
@@ -241,6 +244,7 @@ async function main(): Promise<void> {
             );
         },
         onLogRequiredObservable,
+        onSaveEditorDataRequiredObservable,
     };
 
     SmartFilterEditorControl.Show(options);


### PR DESCRIPTION
It wasn't preserving editor layout, and future changes to the graph were operating on the wrong instance of the smart filter.