### PR TITLE
Readme edit - Giving localhost port for local dev

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,8 @@ npm install
 npm run start:sfe
 ```
 
+Local Smart Filter demo will run at http://localhost:8080
+
 For VSCode users, if you have installed the Chrome Debugging extension, you can start debugging within VSCode by using the appropriate launch menu.
 
 ## Build Tricks


### PR DESCRIPTION
When running
```
npm start
```
or
```
npm run start:sfe
```

Info of app running at http://localhost:8080 was missing